### PR TITLE
Ignore core interfaces etc from src branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ config/*
 !config/migrations.php
 !config/api_sample.php
 
+public/core/
+
 documents
 
 assets/css/*.map


### PR DESCRIPTION
Directus core extensions should only be included in the `dist` branch, and only in transpiled/minified form. This PR ensures devs don't accidentally check in extensions that shouldn't be commited. 