### PR TITLE
Add check for existence of primary key field on collection creation / item retrieval 

### DIFF
--- a/src/core/Directus/Services/TablesService.php
+++ b/src/core/Directus/Services/TablesService.php
@@ -217,6 +217,7 @@ class TablesService extends AbstractService
      * @throws InvalidRequestException
      * @throws CollectionAlreadyExistsException
      * @throws UnauthorizedException
+     * @throws BadRequestException
      */
     public function createTable($name, array $data = [], array $params = [])
     {

--- a/src/core/Directus/Services/TablesService.php
+++ b/src/core/Directus/Services/TablesService.php
@@ -743,7 +743,13 @@ class TablesService extends AbstractService
         return SchemaService::getCollection($tableName);
     }
 
-    public function hasPrimaryField($fields){
+    /**
+     * @param $fields
+     * @return bool
+     *
+     * Checks that at least one of the fields has primary_key set to true.
+     */
+    public function hasPrimaryField(array $fields){
         $result = false;
 
         foreach($fields as $field){
@@ -755,7 +761,14 @@ class TablesService extends AbstractService
         return $result;
     }
 
-    public function hasUniquePrimaryKey($fields){
+    /**
+     * @param $fields
+     * @return bool
+     *
+     * Checks that a maximum of 1 field has the primary_key field set to true. This will succeed if there are 0
+     * or 1 fields set as the primary key.
+     */
+    public function hasUniquePrimaryKey(array $fields){
         $primaryKeyCount = 0;
         foreach($fields as $field){
             if($field['primary_key'] === true){

--- a/src/core/Directus/Services/TablesService.php
+++ b/src/core/Directus/Services/TablesService.php
@@ -258,6 +258,9 @@ class TablesService extends AbstractService
         if(!$this->hasPrimaryField($data['fields'])){
             throw new BadRequestException("Collection does not have a primary key.");
         }
+        if(!$this->hasUniquePrimaryKey($data['fields'])){
+            throw new BadRequestException("Collection must only have 1 primary key.");
+        }
 
         if ($collection && !$collection->isManaged()) {
             $success = $this->updateTableSchema($collection, $data);
@@ -744,12 +747,22 @@ class TablesService extends AbstractService
         $result = false;
 
         foreach($fields as $field){
-            if($field[primary_key] == true){
+            if($field['primary_key'] === true){
                 $result = true;
                 break;
             }
         }
         return $result;
+    }
+
+    public function hasUniquePrimaryKey($fields){
+        $primaryKeyCount = 0;
+        foreach($fields as $field){
+            if($field['primary_key'] === true){
+                $primaryKeyCount++;
+            }
+        }
+        return $primaryKeyCount <= 1;
     }
 
 

--- a/src/core/Directus/Services/TablesService.php
+++ b/src/core/Directus/Services/TablesService.php
@@ -255,11 +255,12 @@ class TablesService extends AbstractService
             throw new CollectionAlreadyExistsException($name);
         }
 
-        if(!$this->hasPrimaryField($data['fields'])){
-            throw new BadRequestException("Collection does not have a primary key.");
+        if (!$this->hasPrimaryField($data['fields'])) {
+            throw new BadRequestException('Collection does not have a primary key.');
         }
-        if(!$this->hasUniquePrimaryKey($data['fields'])){
-            throw new BadRequestException("Collection must only have 1 primary key.");
+
+        if (!$this->hasUniquePrimaryKey($data['fields'])) {
+            throw new BadRequestException('Collection must only have 1 primary key.');
         }
 
         if ($collection && !$collection->isManaged()) {
@@ -744,37 +745,44 @@ class TablesService extends AbstractService
     }
 
     /**
-     * @param $fields
-     * @return bool
-     *
      * Checks that at least one of the fields has primary_key set to true.
+     *
+     * @param array $fields
+     *
+     * @return bool
      */
-    public function hasPrimaryField(array $fields){
+    public function hasPrimaryField(array $fields)
+    {
         $result = false;
 
-        foreach($fields as $field){
-            if($field['primary_key'] === true){
+        foreach ($fields as $field) {
+            if (ArrayUtils::get($field, 'primary_key') === true){
                 $result = true;
                 break;
             }
         }
+
         return $result;
     }
 
     /**
-     * @param $fields
-     * @return bool
-     *
      * Checks that a maximum of 1 field has the primary_key field set to true. This will succeed if there are 0
      * or 1 fields set as the primary key.
+     *
+     * @param array $fields
+     *
+     * @return bool
      */
-    public function hasUniquePrimaryKey(array $fields){
+    public function hasUniquePrimaryKey(array $fields)
+    {
         $primaryKeyCount = 0;
-        foreach($fields as $field){
-            if($field['primary_key'] === true){
+
+        foreach ($fields as $field) {
+            if (ArrayUtils::get($field, 'primary_key') === true) {
                 $primaryKeyCount++;
             }
         }
+
         return $primaryKeyCount <= 1;
     }
 

--- a/src/core/Directus/Services/TablesService.php
+++ b/src/core/Directus/Services/TablesService.php
@@ -254,6 +254,10 @@ class TablesService extends AbstractService
             throw new CollectionAlreadyExistsException($name);
         }
 
+        if(!$this->hasPrimaryField($data['fields'])){
+            throw new BadRequestException("Collection does not have a primary key.");
+        }
+
         if ($collection && !$collection->isManaged()) {
             $success = $this->updateTableSchema($collection, $data);
         } else {
@@ -734,6 +738,19 @@ class TablesService extends AbstractService
     {
         return SchemaService::getCollection($tableName);
     }
+
+    public function hasPrimaryField($fields){
+        $result = false;
+
+        foreach($fields as $field){
+            if($field[primary_key] == true){
+                $result = true;
+                break;
+            }
+        }
+        return $result;
+    }
+
 
     /**
      * @param string $name


### PR DESCRIPTION
Added some validation to ensure that at least 1 field has primary_key set to true. If this is not the case then it throws a BadRequestException with the error message "Collection does not have a primary key."

Closes #172 