### PR TITLE
Adds extensions to the Composer JSON

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,15 @@
     "slim/twig-view": "^2.3",
     "robmorgan/phinx": "^0.9.2",
     "ramsey/uuid": "^3.7",
-    "wellingguzman/rate-limit": "dev-master"
+    "wellingguzman/rate-limit": "dev-master",
+    "ext-json": "*",
+    "ext-curl": "*",
+    "ext-fileinfo": "*",
+    "ext-pdo": "*",
+    "ext-exif": "*",
+    "ext-mbstring": "*",
+    "ext-openssl": "*",
+    "ext-gd": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7.25"


### PR DESCRIPTION
There are a number of PHP extensions that are required for the project to run that are not explicitly listed in the `composer.json`.

This adds them