### PR TITLE
Fixes errors in the Composer JSON validity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+  "name": "directus/api",
+  "license": "GPL-3.0-only",
+  "description": "Directus 7 API wrapper for custom SQL databases",
   "require": {
     "php": ">=5.6.0",
     "slim/slim": "^3.0.0",
@@ -26,11 +29,6 @@
   },
   "suggest": {
     "paragonie/random_compat": "Generates cryptographically more secure pseudo-random bytes"
-  },
-  "_require": {
-    "rackspace/php-opencloud": "dev-master",
-    "amazonwebservices/aws-sdk-for-php": "1.6.2",
-    "aws/aws-sdk-php": "2.6.*@dev"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR updates the `composer.json` such that `composer validate` no longer throws any errors.

Before

```
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
name : The property name is required
description : The property description is required
The property _require is not defined and the definition does not allow additional properties
No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
require.wellingguzman/oauth2-okta : unbound version constraints (dev-master) should be avoided
require.wellingguzman/rate-limit : unbound version constraints (dev-master) should be avoided
```

After

```
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
require.wellingguzman/oauth2-okta : unbound version constraints (dev-master) should be avoided
require.wellingguzman/rate-limit : unbound version constraints (dev-master) should be avoided
```