### PR TITLE
File-Preview Interface: Image Cropper Added

### DIFF
--- a/extensions/core/interfaces/file-preview/input.vue
+++ b/extensions/core/interfaces/file-preview/input.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="isImage" class="image">
-      <img :src="url">
+      <img id="image" :src="vUrl">
     </div>
     <div v-else-if="isVideo" class="video">
       <video controls>
@@ -19,18 +19,94 @@
       {{ fileType }}
     </div>
     <div class="toolbar">
-      <span class="original">
-        <a :href="url" target="_blank"><i class="material-icons">link</i>{{url}}</a>
-      </span>
+
+      <!-- Default Toolbar -->
+      <div v-if="!editMode" class="original">
+        <a 
+          class="file-link" 
+          :href="url" 
+          target="_blank">
+          <i class="material-icons">link</i>
+          {{url}}
+        </a>
+        <button 
+          v-if="isImage && options.edit.includes('image_editor')" 
+          type="button"
+          title="Edit image"
+          class="image-edit-start" 
+          @click="initImageEdit()">
+          <i class="material-icons">crop_rotate</i>
+        </button>
+      </div>
+
+      <!-- Image Edit Toolbar -->
+      <ul v-if="editMode" class="image-edit">
+        <li>
+          <div class="image-aspect-ratio">
+            <i class="material-icons">image_aspect_ratio</i>
+            <span>{{image.cropRatioOptions[image.cropRatio]}}</span>
+            <i class="material-icons">arrow_drop_down</i>
+            <select v-model="image.cropRatio" title="Select aspect ratio">
+              <option
+                v-for="(option,value) in image.cropRatioOptions"
+                :key="value"
+                :value="value">
+                {{option}}
+              </option>
+            </select>
+          </div>
+        </li>
+        <li>
+          <button type="button" title="Discard changes" @click="cancelImageEdit()">
+            <i class="material-icons">not_interested</i>
+          </button>
+          <button type="button" title="Save changes" @click="saveImage()">
+            <i class="material-icons">check_circle</i>
+          </button>
+        </li>
+        <li>
+          <button type="button" title="Flip horizontally" @click="flipImage()">
+            <i class="material-icons">flip</i>
+          </button>
+          <button type="button" title="Rotate counter-clockwise" @click="rotateImage()">
+            <i class="material-icons">rotate_90_degrees_ccw</i>
+          </button>
+        </li>
+      </ul>
     </div>
   </div>
 </template>
 
 <script>
 import mixin from "../../../mixins/interface";
+import Cropper from "cropperjs";
+import "cropperjs/dist/cropper.min.css";
 
 export default {
   mixins: [mixin],
+  data() {
+    return {
+      editMode: null,
+      image: {
+        version: 0, //To prevent the cacheing issue of image
+        cropper: null, //cropper instance
+        cropRatio: "free", // Aspect ratio set by cropper
+        cropRatioOptions: {
+          free: "Free",
+          original: "Original",
+          "1:1": "Square",
+          "16:9": "16:9",
+          "4:3": "4:3",
+          "3:2": "3:2"
+        }
+      }
+    };
+  },
+  watch: {
+    "image.cropRatio"(newValue) {
+      this.setAspectRatio(newValue);
+    }
+  },
   computed: {
     isImage() {
       switch (this.values.type) {
@@ -67,6 +143,98 @@ export default {
     },
     url() {
       return this.values.data.full_url;
+    },
+    vUrl() {
+      /**
+       * Timestamp fetches the latest image from server
+       * Version helps to refresh the image after crop
+       */
+      return `${this.values.data.full_url}?v=${
+        this.image.version
+      }&timestamp=${new Date().getTime()}`;
+    }
+  },
+  methods: {
+    initImageEdit() {
+      this.editMode = "image";
+      let _this = this;
+      let _image = document.getElementById("image");
+      this.image.cropper = new Cropper(_image, {
+        background: false,
+        viewMode: 0,
+        autoCropArea: 1,
+        zoomable: false
+      });
+    },
+
+    cancelImageEdit() {
+      this.editMode = null;
+      this.image.cropRatio = "free";
+      this.image.cropper.destroy();
+    },
+
+    setAspectRatio(value) {
+      let _aspectRatio;
+      switch (value) {
+        case "free":
+          _aspectRatio = "free";
+          break;
+        case "original":
+          _aspectRatio = this.image.cropper.getImageData().aspectRatio;
+          break;
+        default:
+          let _values = value.split(":");
+          _aspectRatio = _values[0] / _values[1];
+          break;
+      }
+      this.image.cropper.setAspectRatio(_aspectRatio);
+    },
+
+    flipImage() {
+      this.image.cropper.scale(-this.image.cropper.getData().scaleX, 1);
+    },
+
+    rotateImage() {
+      this.image.cropper.rotate(-90);
+    },
+
+    saveImage() {
+      let isSaving = this.$helpers.shortid.generate();
+      this.$store.dispatch("loadingStart", {
+        id: isSaving
+      });
+
+      let _imageBase64 = this.image.cropper.getCroppedCanvas().toDataURL();
+      this.$api
+        .patch(`/files/${this.values.id}`, {
+          data: _imageBase64
+        })
+        .then(res => {
+          this.$events.emit("success", {
+            notify: "Image updated."
+          });
+        })
+        .catch(err => {
+          this.$events.emit("error", {
+            notify: "There was an error while saving the image",
+            error: err
+          });
+        })
+        .then(() => {
+          var _this = this;
+          this.image.version++;
+          this.$store.dispatch("loadingFinished", isSaving);
+          /**
+           * This will wait for new cropped image to load from server
+           * & then destroy the cropper instance
+           * This prevents flickering between old and new image
+           */
+          const img = new Image();
+          img.src = this.vUrl;
+          img.onload = function() {
+            _this.cancelImageEdit();
+          };
+        });
     }
   }
 };
@@ -110,24 +278,131 @@ export default {
   color: var(--lighter-gray);
 }
 .toolbar {
-  a {
-    transition: var(--fast) var(--transition);
-    text-decoration: none;
+  margin-top: 10px;
+  .original {
+    display: flex;
+    align-items: flex-start;
+  }
+}
+.file-link {
+  transition: var(--fast) var(--transition);
+  text-decoration: none;
+  color: var(--gray);
+  &:hover {
+    color: var(--darker-gray);
+  }
+  i {
+    margin-right: 6px;
     color: var(--gray);
-    &:hover {
-      color: var(--darker-gray);
-    }
   }
   span {
     margin-right: 10px;
     vertical-align: middle;
   }
-  .original {
-    display: inline-block;
-    margin-top: 10px;
-    i {
-      margin-right: 6px;
+}
+.image-edit-start {
+  margin-left: 10px;
+  i {
+    color: var(--gray);
+  }
+}
+
+.image-edit {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  > li {
+    flex: 0 0 33.33%;
+    text-align: center;
+    button {
+      color: var(--dark-gray);
+      + button {
+        margin-left: 10px;
+      }
+      &:hover {
+        color: var(--darkest-gray);
+      }
+    }
+    &:first-child {
+      text-align: left;
+    }
+    &:last-child {
+      text-align: right;
     }
   }
 }
+
+.image-aspect-ratio {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  span {
+    margin-left: 8px;
+  }
+  select {
+    cursor: pointer;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+  }
+}
 </style>
+
+<style lang="scss">
+.image {
+  .cropper-point {
+    background: #fff;
+    height: 10px;
+    width: 10px;
+    border-radius: 50%;
+    opacity: 1;
+    &.point-n {
+      top: -5px;
+      margin-left: -5px;
+    }
+    &.point-ne {
+      right: -5px;
+      top: -5px;
+    }
+    &.point-e {
+      margin-top: -5px;
+      right: -5px;
+    }
+    &.point-se {
+      right: -5px;
+      bottom: -5px;
+    }
+    &.point-s {
+      bottom: -5px;
+      margin-left: -5px;
+    }
+    &.point-sw {
+      left: -5px;
+      bottom: -5px;
+    }
+    &.point-w {
+      margin-top: -5px;
+      left: -5px;
+    }
+    &.point-nw {
+      left: -5px;
+      top: -5px;
+    }
+  }
+  .cropper-dashed {
+    border-style: solid;
+    border-color: #fff;
+    opacity: 0.4;
+    box-shadow: 0 0px 0px 1px rgba(0, 0, 0, 0.3);
+  }
+  .cropper-line {
+    background-color: #000;
+    opacity: 0.05;
+  }
+}
+</style>
+

--- a/extensions/core/interfaces/file-preview/meta.json
+++ b/extensions/core/interfaces/file-preview/meta.json
@@ -4,10 +4,22 @@
   "types": ["string"],
   "hideLabel": true,
   "icon": "image",
-  "options": {},
+  "options": {
+    "edit": {
+      "name": "$t:edit",
+      "interface": "checkboxes",
+      "default": ["image_editor"],
+      "options": {
+        "choices": {
+          "image_editor": "Image Editor"
+        }
+      }
+    }
+  },
   "translation": {
     "en-US": {
-      "file_preview": "File Preview"
+      "file_preview": "File Preview",
+      "edit": "Editing Options"
     }
   }
 }

--- a/extensions/core/interfaces/file-preview/package.json
+++ b/extensions/core/interfaces/file-preview/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@directus/file-preview",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cropperjs": "^1.4.2"
+  },
+  "devDependencies": {
+    "babel-core": "^6.26.3"
+  }
+}


### PR DESCRIPTION
Features added:
- Cropping
- Rotating
- Flipping
- Aspect Ratio

Image cropping can be enabled by enabling 'Image Editor' option in 'Editing Options' section of Interface. I've chosen to keep checkboxes because in future we can add other media editing options.
Note:
Kindly have a look at how I've managed the image caching issue. If you can suggest a better option, I'll update that.
Also, a large base64 string throws an error due to Directus activity column.
