### PR TITLE
Fix issue #571 in directus/api

### DIFF
--- a/extensions/package.json
+++ b/extensions/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "npx recursive-install --skip-root",
     "prebuild": "npm run clear",
-    "clear": "rm -rf ../public/extensions/core/{interfaces,layouts,pages}",
+    "clear": "rimraf ../public/extensions/core/{interfaces,layouts,pages}",
     "dev:json": "cpx \"core/**/meta.json\" ../public/extensions/core -w",
     "dev:php": "cpx \"core/**/{hooks.php,endpoints.php}\" ../public/extensions/core",
     "dev:vue": "parcel watch core/**/*.vue -d ../public/extensions/core --no-source-maps --global __DirectusExtension__",
@@ -34,6 +34,7 @@
     "node-sass": "^4.9.4",
     "parcel-bundler": "^1.10.3",
     "recursive-install": "^1.3.0",
+    "rimraf": "^2.6.2",
     "through2": "^2.0.3",
     "vue-template-compiler": "^2.5.16"
   },


### PR DESCRIPTION
Replaced *nix shell commands with a cross-platform Node.js alternative [rimraf][1] so that the extensions can be built on non-*nix platforms (eg. Windows).

  [1]: https://www.npmjs.com/package/rimraf