### PR TITLE
Set port based off of scheme if host doesn't include port

### DIFF
--- a/src/helpers/all.php
+++ b/src/helpers/all.php
@@ -169,12 +169,16 @@ if (!function_exists('create_uri_from_global')) {
 
             if (isset($matches[2])) {
                 $port = (int)substr($matches[2], 1);
+            } else {
+                $port = $isSecure ? 443 : 80;
             }
         } else {
             $pos = strpos($host, ':');
             if ($pos !== false) {
                 $port = (int)substr($host, $pos + 1);
                 $host = strstr($host, ':', true);
+            } else {
+                $port = $isSecure ? 443 : 80;
             }
         }
 


### PR DESCRIPTION
When directus api will assume the port is 80 even when the host string doesn't include a port but the scheme is https.

This adds a quick check for that case.
