### PR TITLE
UX fix - Better experience for user if upload .pdf

### DIFF
--- a/extensions/core/interfaces/file/get-icon.js
+++ b/extensions/core/interfaces/file/get-icon.js
@@ -1,4 +1,9 @@
 export default function getIcon(type) {
+
+  if (type === "application/pdf") {
+    return "picture_as_pdf";
+  }
+
   if (type.startsWith("application")) {
     return "insert_drive_file";
   }

--- a/extensions/core/interfaces/file/input.vue
+++ b/extensions/core/interfaces/file/input.vue
@@ -5,7 +5,9 @@
       class="card"
       :title="value.title"
       :subtitle="subtitle"
-      :src="value.data.full_url"
+      :src="src"
+      :icon="icon"
+      :href="href"
       :options="{
         remove: {
           text: $t('delete'),
@@ -58,6 +60,7 @@
 
 <script>
 import mixin from "../../../mixins/interface";
+import getIcon from "./get-icon";
 
 export default {
   mixins: [mixin],
@@ -81,6 +84,15 @@ export default {
         " • " +
         this.$d(new Date(this.value.uploaded_on), "short")
       );
+    },
+    src() {
+      return this.value.type && this.value.type.startsWith("image") ? this.value.data.full_url : null;
+    },
+    icon() {
+      return this.value.type && !this.value.type.startsWith("image") ? getIcon(this.value.type) : null;
+    },
+    href() { 
+      return this.value.type && this.value.type === "application/pdf" ? this.value.data.full_url : null;
     },
     viewOptions() {
       const viewOptions = this.options.viewOptions;


### PR DESCRIPTION
Hello, PR solves a problem when the user uploads successfully .pdf.

Step to reproduce. Upload .pdf file. Everything is successful but user see broken icon and can not clicks on any link to check if .pdf is OK.

Also works for a video icon. I do not know if you would like to link to video too.