### PR TITLE
Feature - Custom storage

### DIFF
--- a/config/api_sample.php
+++ b/config/api_sample.php
@@ -69,7 +69,48 @@ return [
         //   'version' => 's3-version',
         //   'bucket' => 's3-bucket'
     ],
-
+    /*
+    //Custom srorage
+    'storage' => [
+        'adapter' => 'custom',
+        'root' => '/',
+        //If you have on your CDN different paths for images and docs. Can be you use a little tweak.
+        //Remove /img from 'root_url' and 'thumb_root' and modify your adapter response for the method write().
+        //From ['fileName' => image.jpg] to ['fileName' => img/image.jpg]. Directus can handle this. But here 
+        //is one disclaimer. With the tweak, you have to use 'thumbnails_hook' minimally in default form. Because
+        //Thumbnailer can not handle this.
+        'root_url'   => 'https://cdn.example.com/img',
+        'thumb_root' => 'https://cdn.example.com/img',
+        // class_adapter is required. 
+        // The namespace of your Adapter which implements \League\Flysystem\Adapter\AdapterInterface.
+        // This confing is accesible in Adapater in constructor.
+        'class_adapter'  => \Some\Name\Adapter::class,
+        // class_filesystem is optional. 
+        // The namespace of your Filesystem which extends \League\Flysystem\Filesystem
+        // This is needed if your storage(CDN) is changing the file name. Also need when you use the tweak.
+        // You have to overload \League\Flysystem\Filesystem::write() and remove retyping to boolean and return 
+        // ['fileName' => 'image.jpg']
+        'class_filesystem'  => \Some\Name\Filesystem::class,
+        // Domain for uploading is optional. Can be used in your Adapter.
+        'upload_url'  => 'https://upload.cdn.example.com',
+        // Hook for thumbnails is optional. Can be used if your thumbnails are accessible via file name(example)
+        // or you just do not want use Thumbnailer or you have to when use tweak with fileName. The minimal form
+        // is just return $thumbnail with no modification. If 'thumbnails_hook' is comment Directus take control and thumbnails are
+        // made same as for S3.
+        'thumbnails_hook' => function ($thumbnail) {
+            //default
+            return $thumbnail;
+            //Example: https://cdn.example.com/image/123456.jpg -> https://cdn.example.com/image/123456_w200_h200.jpg
+            //return [
+            //    'url' => preg_replace("/(.jpg$|.png$)/", "_rw".$thumbnail['width']."_rh".$thumbnail['height']."$1", $thumbnail['url']),
+            //    'relative_url' =>  preg_replace("/(.jpg$|.png$)/", "_rw".$thumbnail['width']."_rh".$thumbnail['height']."$1", $thumbnail['relative_url']),
+            //    'dimension' =>  $thumbnail['dimension'],
+            //    'width' => $thumbnail['width'],
+            //    'height' => $thumbnail['height'],
+            //];
+        },
+    ],
+    */
     'mail' => [
         'default' => [
             'transport' => 'sendmail',

--- a/src/core/Directus/Filesystem/Filesystem.php
+++ b/src/core/Directus/Filesystem/Filesystem.php
@@ -49,6 +49,8 @@ class Filesystem
      * @param string $location
      * @param $data
      * @param bool $replace
+     *
+     * @return array|null - array if League\Flysystem\Filesystem::write() is overload
      */
     public function write($location, $data, $replace = false)
     {
@@ -61,12 +63,14 @@ class Filesystem
         }
 
         try {
-            if (!$this->getAdapter()->write($location, $data)) {
+            if (!$fileInfo = $this->getAdapter()->write($location, $data)) {
                 $throwException();
             }
         } catch (\Exception $e) {
             $throwException();
         }
+
+        return is_array($fileInfo) ? $fileInfo : null; //null for a better legacy. In the past method return void.
     }
 
     /**

--- a/src/core/Directus/Filesystem/FilesystemFactory.php
+++ b/src/core/Directus/Filesystem/FilesystemFactory.php
@@ -19,6 +19,9 @@ class FilesystemFactory
             case 's3':
                 return self::createS3Adapter($config, $rootKey);
                 break;
+            case 'custom':
+                return self::createCustomAdapter($config, $rootKey);
+                break;
             case 'local':
             default:
                 return self::createLocalAdapter($config, $rootKey);
@@ -52,5 +55,14 @@ class FilesystemFactory
         ]);
 
         return new Flysystem(new S3Adapter($client, $config['bucket'], array_get($config, $rootKey)));
+    }
+
+    public static function createCustomAdapter(Array $config, $rootKey = 'root')
+    {
+        if(isset($config['class_filesystem']) && class_exists($config['class_filesystem'])) {
+            return new $config['class_filesystem'](new $config['class_adapter']($config, $rootKey));
+        }
+
+        return new Flysystem(new $config['class_adapter']($config, $rootKey));
     }
 }


### PR DESCRIPTION
Hi, this PR contains custom storage.

- In the config, you set an instance of Adapter - required
- In the config, you set an instance of Filesystem - optional (If you want to change file name)
- Possible use a little tweak if storage uses different paths for images and docs etc... (closer in api_samle.php). I have found column folder in directus_files but has int(11) and I do not know how it works.
- Added thumbnails hook.  Reasons:

1. Every storage has own logic for creating paths and file names for thumbs and default behavior is too specific.
2. Can be skipped Thumbnailer and use only CSS resize.
3. It is possible to completely modify URLs of thumbs.
4. Hook reflects dimensions.

More info is in api_samle.php

Tested with S3 and everything seems fine. But the deeper check is required. I do not know if I have found everything which is connected with this PR.

Probably opens the door for https://github.com/directus/api/issues/509 