### PR TITLE
Fixed database installer

### DIFF
--- a/src/core/Directus/Util/Installation/InstallerUtils.php
+++ b/src/core/Directus/Util/Installation/InstallerUtils.php
@@ -631,7 +631,7 @@ class InstallerUtils
             [
                 'scope' => 'global',
                 'key' => 'color',
-                'value' => 'light-blue-400'
+                'value' => 'light-blue-600'
             ],
             [
                 'scope' => 'files',

--- a/src/core/Directus/Util/Installation/InstallerUtils.php
+++ b/src/core/Directus/Util/Installation/InstallerUtils.php
@@ -629,6 +629,11 @@ class InstallerUtils
                 'value' => ''
             ],
             [
+                'scope' => 'global',
+                'key' => 'color',
+                'value' => 'light-blue-400'
+            ],
+            [
                 'scope' => 'files',
                 'key' => 'youtube_api_key',
                 'value' => ''

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -495,7 +495,8 @@ VALUES
 	(2,'global','project_name','Directus'),
 	(3,'global','default_limit','200'),
 	(4,'global','logo',''),
-	(5,'files','youtube_api_key','');
+	(5,'global','color','light-blue-400'),
+	(6,'files','youtube_api_key','');
 
 /*!40000 ALTER TABLE `directus_settings` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -495,7 +495,7 @@ VALUES
 	(2,'global','project_name','Directus'),
 	(3,'global','default_limit','200'),
 	(4,'global','logo',''),
-	(5,'global','color','light-blue-400'),
+	(5,'global','color','light-blue-600'),
 	(6,'files','youtube_api_key','');
 
 /*!40000 ALTER TABLE `directus_settings` ENABLE KEYS */;

--- a/tests/db.sql
+++ b/tests/db.sql
@@ -556,7 +556,8 @@ VALUES
 	(2,'global','project_name','Directus'),
 	(3,'global','default_limit','200'),
 	(4,'global','logo',''),
-	(5,'files','youtube_api_key','');
+	(5,'global','color','light-blue-400'),
+	(6,'files','youtube_api_key','');
 
 /*!40000 ALTER TABLE `directus_settings` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/tests/db.sql
+++ b/tests/db.sql
@@ -556,7 +556,7 @@ VALUES
 	(2,'global','project_name','Directus'),
 	(3,'global','default_limit','200'),
 	(4,'global','logo',''),
-	(5,'global','color','light-blue-400'),
+	(5,'global','color','light-blue-600'),
 	(6,'files','youtube_api_key','');
 
 /*!40000 ALTER TABLE `directus_settings` ENABLE KEYS */;


### PR DESCRIPTION
Hi, when you try to change the `color` from the APP in `Global Settings` you get an error:

<img width="737" alt="schermata 2018-11-23 alle 00 29 00" src="https://user-images.githubusercontent.com/1681269/48924378-9c175200-eeb7-11e8-83c4-90b9869767b6.png">

I only added the default property to the installer.