### PR TITLE
Remove scope from directus_settings

### DIFF
--- a/migrations/db/schemas/20180220023243_create_settings_table.php
+++ b/migrations/db/schemas/20180220023243_create_settings_table.php
@@ -29,10 +29,6 @@ class CreateSettingsTable extends AbstractMigration
     {
         $table = $this->table('directus_settings', ['signed' => false]);
 
-        $table->addColumn('scope', 'string', [
-            'limit' => 64,
-            'default' => null
-        ]);
         $table->addColumn('key', 'string', [
             'limit' => 64,
             'null' => false
@@ -41,7 +37,7 @@ class CreateSettingsTable extends AbstractMigration
             'default' => null
         ]);
 
-        $table->addIndex(['scope', 'key'], [
+        $table->addIndex(['key'], [
             'unique' => true,
             'name' => 'idx_scope_name'
         ]);

--- a/migrations/upgrades/schemas/20181123171520_remove_scope.php
+++ b/migrations/upgrades/schemas/20181123171520_remove_scope.php
@@ -1,0 +1,14 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class RemoveScope extends AbstractMigration
+{
+    public function up()
+    {
+        $table = $this->table('directus_settings');
+        $table->removeColumn('scope')
+              ->save();
+    }
+}


### PR DESCRIPTION
Adds a migration to remove the scope column.

Closes #594, ref https://github.com/directus/app/issues/1140