### PR TITLE
Support Bundled Extensions (Packages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ composer.lock
 !/public/extensions/custom/endpoints/_example.php
 
 ##  Hashers
-!/public/extensions/custom/hashers/_CustomHasher.php
+!/public/extensions/custom/hasher/_CustomHasher.php
 
 ##  Hooks
 !/public/extensions/custom/hooks/_products

--- a/.gitignore
+++ b/.gitignore
@@ -24,16 +24,11 @@ composer.lock
 /phpunit.xml
 /documents
 
-# Core extensions
-/public/extensions/core/interfaces
-/public/extensions/core/layouts
-/public/extensions/core/pages
-
-# Custom extensions
-/public/extensions/custom/*/*
+# Extensions
+/public/extensions/*/*
 
 ##  Auth
-/public/extensions/custom/auth
+!/public/extensions/core/auth
 
 ##  Endpoints
 !/public/extensions/custom/endpoints/_directory/

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,6 @@
       "Directus\\": "src/core/Directus/",
       "Directus\\Authentication\\Sso\\Provider\\": "public/extensions/core/auth",
       "Directus\\Api\\Routes\\": "src/endpoints/",
-      "Directus\\Custom\\Embed\\Provider\\": "public/extensions/custom/embeds/",
       "Directus\\Extensions\\Custom\\": "public/extensions/custom/"
     },
     "files": [

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
       "Directus\\Api\\Routes\\": "src/endpoints/",
       "Directus\\Custom\\Embed\\Provider\\": "public/extensions/custom/embeds/",
       "Directus\\Custom\\Hooks\\": "public/extensions/custom/hooks/",
-      "Directus\\Custom\\Hasher\\": "public/extensions/custom/hashers/"
+      "Directus\\Extensions\\Custom\\": "public/extensions/custom/"
     },
     "files": [
       "src/helpers/all.php"

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
       "Directus\\Authentication\\Sso\\Provider\\": "public/extensions/core/auth",
       "Directus\\Api\\Routes\\": "src/endpoints/",
       "Directus\\Custom\\Embed\\Provider\\": "public/extensions/custom/embeds/",
-      "Directus\\Custom\\Hooks\\": "public/extensions/custom/hooks/",
       "Directus\\Extensions\\Custom\\": "public/extensions/custom/"
     },
     "files": [

--- a/config/api_sample.php
+++ b/config/api_sample.php
@@ -110,6 +110,11 @@ return [
         'filters' => [],
     ],
 
+    // These extensions will be loaded
+    'extensions' => [
+        'custom',
+    ],
+
     'feedback' => [
         'token' => 'a-kind-of-unique-token',
         'login' => true

--- a/public/extensions/custom/endpoints/_directory/controllers/Home.php
+++ b/public/extensions/custom/endpoints/_directory/controllers/Home.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Directus\Extensions\Custom\Endpoints\Directory\Controllers;
+
 use Directus\Application\Http\Request;
 use Directus\Application\Http\Response;
 

--- a/public/extensions/custom/endpoints/_directory/endpoints.php
+++ b/public/extensions/custom/endpoints/_directory/endpoints.php
@@ -1,6 +1,6 @@
 <?php
 
-require __DIR__ . '/controllers/Home.php';
+use Directus\Extensions\Custom\Endpoints\Directory\Controllers\Home;
 
 return [
     '' => [

--- a/public/extensions/custom/hasher/_CustomHasher.php
+++ b/public/extensions/custom/hasher/_CustomHasher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Directus\Custom\Hasher;
+namespace Directus\Extensions\Custom\Hasher;
 
 class CustomHasher implements \Directus\Hash\Hasher\HasherInterface
 {

--- a/public/extensions/custom/hooks/_products/BeforeInsertProducts.php
+++ b/public/extensions/custom/hooks/_products/BeforeInsertProducts.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Directus\Custom\Hooks\Products;
+namespace Directus\Extensions\Custom\Hooks\Products;
 
 use Directus\Hook\HookInterface;
 use Directus\Hook\Payload;

--- a/public/extensions/custom/hooks/_products/hooks.php
+++ b/public/extensions/custom/hooks/_products/hooks.php
@@ -2,6 +2,6 @@
 
 return [
     'filters' => [
-        'item.create:before' => new \Directus\Custom\Hooks\Products\BeforeInsertProducts()
+        'item.create:before' => new \Directus\Extensions\Custom\Hooks\Products\BeforeInsertProducts()
     ]
 ];

--- a/src/core/Directus/Application/CoreServicesProvider.php
+++ b/src/core/Directus/Application/CoreServicesProvider.php
@@ -1093,11 +1093,21 @@ class CoreServicesProvider
     {
         return function (Container $container) {
             $basePath = $container->get('path_base');
+            $extensions = $container->get('config')->get('extensions', []);
 
-            return new Twig([
-                $basePath . '/public/extensions/custom/mail',
-                $basePath . '/src/mail'
-            ]);
+            $paths = [];
+            foreach($extensions as $extension) {
+                $extensionPath = "$basePath/public/extensions/$extension/mail";
+
+                if (!file_exists($extensionPath)) {
+                    continue;
+                }
+
+                $paths[] = $extensionPath;
+            }
+            $paths[] = $basePath . '/src/mail';
+
+            return new Twig($paths);
         };
     }
 

--- a/src/core/Directus/Services/AuthService.php
+++ b/src/core/Directus/Services/AuthService.php
@@ -90,8 +90,7 @@ class AuthService extends AbstractService
         $basePath = $this->container->get('path_base');
 
         $iconUrl = null;
-        $type = $service->getConfig()->get('custom') === true ? 'custom' : 'core';
-        $iconPath = sprintf('/extensions/%s/auth/%s/icon.svg', $type, $name);
+        $iconPath = sprintf('/extensions/%s/auth/%s/icon.svg', $service->getConfig()->get('extensionName'), $name);
         if (file_exists($basePath . '/public' . $iconPath)) {
             $iconUrl = \Directus\get_url($iconPath);
         }

--- a/src/core/Directus/Services/InterfacesService.php
+++ b/src/core/Directus/Services/InterfacesService.php
@@ -11,11 +11,15 @@ class InterfacesService extends AbstractExtensionsController
         parent::__construct($container);
 
         $basePath = $this->container->get('path_base');
+        $extensions = $this->container->get('config')->get('extensions', []);
 
         $this->paths = [
             $basePath . '/public/extensions/core/interfaces',
-            $basePath . '/public/extensions/custom/interfaces',
         ];
+
+        foreach ($extensions as $extension) {
+            $this->paths[] = "$basePath/public/extensions/$extension/interfaces";
+        }
     }
 
     public function findAll(array $params = [])

--- a/src/core/Directus/Services/LayoutsService.php
+++ b/src/core/Directus/Services/LayoutsService.php
@@ -11,10 +11,15 @@ class LayoutsService extends AbstractExtensionsController
         parent::__construct($container);
 
         $basePath = $this->container->get('path_base');
+        $extensions = $this->container->get('config')->get('extensions', []);
+
         $this->paths = [
             $basePath . '/public/extensions/core/layouts',
-            $basePath . '/public/extensions/custom/layouts',
         ];
+
+        foreach ($extensions as $extension) {
+            $this->paths[] = "$basePath/public/extensions/$extension/layouts";
+        }
     }
 
     public function findAll(array $params = [])

--- a/src/core/Directus/Services/PagesService.php
+++ b/src/core/Directus/Services/PagesService.php
@@ -11,10 +11,15 @@ class PagesService extends AbstractExtensionsController
         parent::__construct($container);
 
         $basePath = $this->container->get('path_base');
+        $extensions = $this->container->get('config')->get('extensions', []);
+
         $this->paths = [
             $basePath . '/public/extensions/core/pages',
-            $basePath . '/public/extensions/custom/pages',
         ];
+
+        foreach ($extensions as $extension) {
+            $this->paths[] = "$basePath/public/extensions/$extension/pages";
+        }
     }
 
     public function findAll(array $params = [])

--- a/src/helpers/all.php
+++ b/src/helpers/all.php
@@ -371,10 +371,14 @@ if (!function_exists('register_extensions_hooks')) {
      */
     function register_extensions_hooks(Application $app)
     {
-        register_hooks_list(
-            $app,
-            get_custom_hooks('public/extensions/custom/hooks')
-        );
+        $extensions = $app->getConfig()->get('extensions', []);
+
+        foreach ($extensions as $extension) {
+            register_hooks_list(
+                $app,
+                get_custom_hooks("public/extensions/$extension/hooks")
+            );
+        }
 
         register_hooks_list(
             $app,

--- a/src/helpers/extensions.php
+++ b/src/helpers/extensions.php
@@ -168,7 +168,7 @@ if (!function_exists('get_custom_hooks')) {
     }
 }
 
-if (!function_exists('get_custom_hooks')) {
+if (!function_exists('get_classes_from_extension_subdirectory')) {
     /**
      * Get a list of classes from a given subdirectory of an extension
      *

--- a/src/helpers/extensions.php
+++ b/src/helpers/extensions.php
@@ -5,6 +5,7 @@ namespace Directus;
 use Directus\Application\Application;
 use Directus\Exception\Exception;
 use Directus\Util\ArrayUtils;
+use Directus\Util\StringUtils;
 
 if (!function_exists('get_custom_x')) {
     /**
@@ -164,5 +165,51 @@ if (!function_exists('get_custom_hooks')) {
     function get_custom_hooks($path, $onlyDirectories = false)
     {
         return get_custom_x('hooks', $path, $onlyDirectories);
+    }
+}
+
+if (!function_exists('get_custom_hooks')) {
+    /**
+     * Get a list of classes from a given subdirectory of an extension
+     *
+     * @param string $subdirectory
+     *
+     * @return array
+     */
+    function get_classes_from_extension_subdirectory($subdirectory) {
+        $container = Application::getInstance()->getContainer();
+        $basePath = $container->get('path_base');
+        $extensions = $container->get('config')->get('extensions', []);
+
+        $classes = [];
+
+        foreach ($extensions as $extension) {
+
+            $path = implode(DIRECTORY_SEPARATOR, [
+                $basePath, 'public', 'extensions', $extension, $subdirectory, '*.php'
+            ]);
+
+            if (empty($files = glob($path))) {
+                continue;
+            }
+
+            $extensionNamespace = '\\Directus\\Extensions\\' . StringUtils::toCamelCase($extension, true, '-');
+
+            foreach ($files as $filename) {
+
+                $name = basename($filename, '.php');
+
+                // filename starting with underscore are skipped
+                if (StringUtils::startsWith($name, '_')) {
+                    continue;
+                }
+
+                $classes[] = $extensionNamespace . '\\' . ucfirst($subdirectory) . '\\' . $name;
+
+            }
+
+        }
+
+        return $classes;
     }
 }


### PR DESCRIPTION
Related to #610 

Added support for bundled extension directories. They can be added next to the default `custom` bundle directory, e.g.:

- `extensions/custom`
- `extensions/my-first-extension`
- `extensions/project-management`

If a directory name contains multiple words, then separate them with a hyphen. 

As usual the bundled extension directory contains the directories for `endpoints`, `hooks`, `interfaces`, `layouts`, `pages` and co.

Bundled extensions that should be activated must be added to the `config/api.php` file:

````php
// These extensions will be loaded
'extensions' => [
    'custom',
    'my-first-extension',
    'project-management',
],
````

For autoloading to work, the bundled extensions also must be added to `composer.json`:

````json
"autoload": {
    "psr-4": {
        "Directus\\Extensions\\Custom\\": "public/extensions/custom/",
        "Directus\\Extensions\\MyFirstExtension\\": "public/extensions/my-first-extensions/",
        "Directus\\Extensions\\ProjectManagement\\": "public/extensions/project-management/"
    }
}
````

Everything else works as usual. 

The only secret I could not solve how to handle migrations of bundled extensions. If I call the `/_/update` route the default migrations from `upgrades/schemas/*.php` are executed and the paths from `config/migrations.php` are overridden in the `InstallerUtils::getMigrationConfig()` method. Maybe someone can point me in the right direction? 