### PR TITLE
Check version variable for MariaDB as well as version_comment

### DIFF
--- a/src/core/Directus/Database/Schema/Sources/MySQLSchema.php
+++ b/src/core/Directus/Database/Schema/Sources/MySQLSchema.php
@@ -713,9 +713,12 @@ class MySQLSchema extends AbstractSchema
     public function isMariaDb()
     {
         if ($this->isMariaDb === null) {
-            $variable = $this->adapter->query('SHOW VARIABLES LIKE "version_comment";')->execute()->current();
-
-            $this->isMariaDb = $variable && strpos(strtolower(ArrayUtils::get($variable, 'Value', '')), 'mariadb') !== false;
+            $this->isMariaDb === false;
+            $variable = $this->adapter->query('SHOW VARIABLES WHERE Variable_Name LIKE "version" OR Variable_Name LIKE "version_comment";')->execute();
+            while($variable->valid() && !$this->isMariaDb) {
+                $this->isMariaDb = $variable->current() && strpos(strtolower(ArrayUtils::get($variable->current(), 'Value', '')), 'mariadb') !== false;
+                $variable->next();
+            }
         }
 
         return $this->isMariaDb;

--- a/src/core/Directus/Database/Schema/Sources/MySQLSchema.php
+++ b/src/core/Directus/Database/Schema/Sources/MySQLSchema.php
@@ -713,11 +713,11 @@ class MySQLSchema extends AbstractSchema
     public function isMariaDb()
     {
         if ($this->isMariaDb === null) {
-            $this->isMariaDb === false;
-            $variable = $this->adapter->query('SHOW VARIABLES WHERE Variable_Name LIKE "version" OR Variable_Name LIKE "version_comment";')->execute();
-            while($variable->valid() && !$this->isMariaDb) {
-                $this->isMariaDb = $variable->current() && strpos(strtolower(ArrayUtils::get($variable->current(), 'Value', '')), 'mariadb') !== false;
-                $variable->next();
+            $this->isMariaDb = false;
+            $result = $this->adapter->query('SHOW VARIABLES WHERE Variable_Name LIKE "version" OR Variable_Name LIKE "version_comment";')->execute();
+            while ($result->valid() && !$this->isMariaDb) {
+                $this->isMariaDb = $result->current() && strpos(strtolower(ArrayUtils::get($result->current(), 'Value', '')), 'mariadb') !== false;
+                $result->next();
             }
         }
 


### PR DESCRIPTION
On AWS at least, _version_comment_ contains the rather unhelpful value "Source distribution". _version_ however contains "10.3.8-MariaDB-log".  This PR is for a suggested widening of the variable search to include _version_ when testing for MariaDB.