### PR TITLE
Remove compound key (‘key’,’scope’) before removing scope column

### DIFF
--- a/migrations/upgrades/schemas/20181123171520_remove_scope.php
+++ b/migrations/upgrades/schemas/20181123171520_remove_scope.php
@@ -13,7 +13,7 @@ class RemoveScope extends AbstractMigration
               ->save();
         $table->addIndex(['key'], [
             'unique' => true,
-            'name' => 'idx_scope_name'
+            'name' => 'idx_key'
         ]);
     }
 }

--- a/migrations/upgrades/schemas/20181123171520_remove_scope.php
+++ b/migrations/upgrades/schemas/20181123171520_remove_scope.php
@@ -8,7 +8,12 @@ class RemoveScope extends AbstractMigration
     public function up()
     {
         $table = $this->table('directus_settings');
+        $table->removeIndexByName('idx_scope_name');
         $table->removeColumn('scope')
               ->save();
+        $table->addIndex(['key'], [
+            'unique' => true,
+            'name' => 'idx_scope_name'
+        ]);
     }
 }


### PR DESCRIPTION
I found that the compound index previously on ('key','scope') prevented the scope column from being removed during this migration.  This PR suggests removing the key then deleting the column then recreating the key as per the current schema in 20180220023243_create_settings_table.

As per the current schema I've left the index name as _idx_scope_name_, although maybe it should just be called _idx_name_ now?