### PR TITLE
Edit file modal for files interface

### DIFF
--- a/extensions/core/interfaces/files/meta.json
+++ b/extensions/core/interfaces/files/meta.json
@@ -60,7 +60,8 @@
       "view_query": "View Query",
       "view_query_comment": "Set the view query to use for the files",
       "filters": "Filters",
-      "filters_comment": "What filters to use"
+      "filters_comment": "What filters to use",
+      "edit_item": "Edit"
     }
   }
 }


### PR DESCRIPTION
Hi guys,

updated the new files interface to feature an edit modal like the M2M interface. You can open it from the card menu of the file

Seems to work well - just a little CSS bug with the tooltip popover `z-index`being above the modal. But I think this would better be fixed by closing the popover `@click` altogether?!?

Let me know if you need anything else! :)