### PR TITLE
pre-encrypt password before call /auth/authenticate

### DIFF
--- a/src/core/Directus/Authentication/Provider.php
+++ b/src/core/Directus/Authentication/Provider.php
@@ -156,8 +156,10 @@ class Provider
             throw new InvalidUserCredentialsException();
         }
         
-        // check algo
-        
+        // example: base64-rot13-base64
+        if($algo == "base64-rot13-base64") {
+            $password = base64_decode(str_rot13(base64_decode($password)));
+        }
 
         // Verify that the user has an id (exists), it returns empty user object otherwise
         if (!password_verify($password, $user->get('password'))) {

--- a/src/core/Directus/Authentication/Provider.php
+++ b/src/core/Directus/Authentication/Provider.php
@@ -108,11 +108,12 @@ class Provider
     {
         $email = ArrayUtils::get($credentials, 'email');
         $password = ArrayUtils::get($credentials, 'password');
+        $algo = ArrayUtils::get($credentials, 'algo');
 
         $user = null;
         if ($email && $password) {
             // Verify Credentials
-            $user = $this->findUserWithCredentials($email, $password);
+            $user = $this->findUserWithCredentials($email, $password, $algo);
             $this->setUser($user);
         }
 
@@ -147,13 +148,16 @@ class Provider
      *
      * @throws InvalidUserCredentialsException
      */
-    public function findUserWithCredentials($email, $password)
+    public function findUserWithCredentials($email, $password, $algo="")
     {
         try {
             $user = $this->findUserWithEmail($email);
         } catch (UserWithEmailNotFoundException $e) {
             throw new InvalidUserCredentialsException();
         }
+        
+        // check algo
+        
 
         // Verify that the user has an id (exists), it returns empty user object otherwise
         if (!password_verify($password, $user->get('password'))) {

--- a/src/core/Directus/Services/AuthService.php
+++ b/src/core/Directus/Services/AuthService.php
@@ -34,7 +34,7 @@ class AuthService extends AbstractService
      *
      * @throws UnauthorizedException
      */
-    public function loginWithCredentials($email, $password)
+    public function loginWithCredentials($email, $password, $algo="")
     {
         $this->validateCredentials($email, $password);
 
@@ -44,7 +44,8 @@ class AuthService extends AbstractService
         /** @var UserInterface $user */
         $user = $auth->login([
             'email' => $email,
-            'password' => $password
+            'password' => $password,
+            'algo' => $algo
         ]);
 
         $hookEmitter = $this->container->get('hook_emitter');

--- a/src/endpoints/Auth.php
+++ b/src/endpoints/Auth.php
@@ -47,7 +47,7 @@ class Auth extends Route
         $responseData = $authService->loginWithCredentials(
             $request->getParsedBodyParam('email'),
             $request->getParsedBodyParam('password'),
-            $request->getParsedBodyParam('algo')
+            $request->getParsedBodyParam('algo') // protect password of directus based apps
         );
 
         return $this->responseWithData($request, $response, $responseData);

--- a/src/endpoints/Auth.php
+++ b/src/endpoints/Auth.php
@@ -46,7 +46,8 @@ class Auth extends Route
 
         $responseData = $authService->loginWithCredentials(
             $request->getParsedBodyParam('email'),
-            $request->getParsedBodyParam('password')
+            $request->getParsedBodyParam('password'),
+            $request->getParsedBodyParam('algo')
         );
 
         return $this->responseWithData($request, $response, $responseData);


### PR DESCRIPTION
I was asked about pre-encryption while using directus.
This is because there was an unintended plaintext exposure while using the API.
HTTPS communication can solve this, but it is not a complete answer.
I want to find a new way to handle password.