### PR TITLE
Configure custom S3 Endpoint

### DIFF
--- a/config/api_sample.php
+++ b/config/api_sample.php
@@ -69,6 +69,8 @@ return [
         //   'version' => 's3-version',
         //   'bucket' => 's3-bucket',
         //   'options' => ['ACL' => 'public-read', 'Cache-Control' => 'max-age=604800']
+        // Set custom S3 endpoint
+        //   'endpoint' => 's3-endpoint',
     ],
 
     'mail' => [

--- a/src/core/Directus/Filesystem/FilesystemFactory.php
+++ b/src/core/Directus/Filesystem/FilesystemFactory.php
@@ -51,7 +51,7 @@ class FilesystemFactory
             'version' => ($config['version'] ?: 'latest'),
         ];
 
-        if ($config['endpoint']) {
+        if (isset($config['endpoint'])) {
           $options['endpoint'] = $config['endpoint'];
           $options['use_path_style_endpoint'] = true;
         }

--- a/src/core/Directus/Filesystem/FilesystemFactory.php
+++ b/src/core/Directus/Filesystem/FilesystemFactory.php
@@ -42,15 +42,21 @@ class FilesystemFactory
 
     public static function createS3Adapter(Array $config, $rootKey = 'root')
     {
-        $client = S3Client::factory([
+        $options = [
             'credentials' => [
                 'key' => $config['key'],
                 'secret' => $config['secret'],
             ],
             'region' => $config['region'],
             'version' => ($config['version'] ?: 'latest'),
-        ]);
+        ];
 
+        if ($config['endpoint']) {
+          $options['endpoint'] = $config['endpoint'];
+          $options['use_path_style_endpoint'] = true;
+        }
+
+        $client = S3Client::factory($options);
         $options = array_get($config, 'options', []);
 
         return new Flysystem(new S3Adapter($client, $config['bucket'], array_get($config, $rootKey), $options));

--- a/src/core/Directus/Filesystem/FilesystemFactory.php
+++ b/src/core/Directus/Filesystem/FilesystemFactory.php
@@ -51,7 +51,7 @@ class FilesystemFactory
             'version' => ($config['version'] ?: 'latest'),
         ];
 
-        if (isset($config['endpoint'])) {
+        if (isset($config['endpoint']) && $config['endpoint']) {
           $options['endpoint'] = $config['endpoint'];
           $options['use_path_style_endpoint'] = true;
         }


### PR DESCRIPTION
This adds the missing configuration for allowing a custom S3 endpoint.
E.g. if you want to use Minio for local development, it can be configured now.