### PR TITLE
Fix errors with array_unshift in RelationalTableGateway

### DIFF
--- a/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -981,12 +981,12 @@ class RelationalTableGateway extends BaseTableGateway
 
         $selectedFields = $this->getSelectedNonAliasFields($fields ?: ['*']);
         if (!in_array($collectionObject->getPrimaryKeyName(), $selectedFields)) {
-            $selectedFields = array_unshift($selectedFields, $collectionObject->getPrimaryKeyName());
+            array_unshift($selectedFields, $collectionObject->getPrimaryKeyName());
         }
 
         $statusField = $collectionObject->getStatusField();
         if ($statusField && !in_array($statusField->getName(), $selectedFields) && $this->acl->getCollectionStatuses($this->table)) {
-            $selectedFields = array_unshift($selectedFields, $statusField->getName());
+            array_unshift($selectedFields, $statusField->getName());
         }
 
         $builder->columns($selectedFields);


### PR DESCRIPTION
I removed assignments when using `array_unshift` because this function returns the number of items in the array instead of the array itself. 
See: https://secure.php.net/manual/en/function.array-unshift.php

Without these changes I am getting an `Internal server error` in some cases.