### PR TITLE
Add filtered_count meta to GET API calls

### DIFF
--- a/src/core/Directus/Database/Query/Builder.php
+++ b/src/core/Directus/Database/Query/Builder.php
@@ -81,6 +81,11 @@ class Builder
     protected $havings = null;
 
     /**
+     * @var boolean
+     */
+    protected $hasQuantifier = false;
+
+    /**
      * Builder constructor.
      *
      * @param AdapterInterface $connection
@@ -585,6 +590,26 @@ class Builder
     }
 
     /**
+     * Sets quantifier
+     *
+     * @return true
+     */
+    public function addQuantifier()
+    {
+        $this->hasQuantifier = true;
+    }
+
+    /**
+     * Gets hasQuantifier
+     *
+     * @return array|null
+     */
+    public function getHasQuantifier()
+    {
+        return $this->hasQuantifier;
+    }
+
+    /**
      * Build the Select Object
      *
      * @return \Zend\Db\Sql\Select
@@ -592,6 +617,11 @@ class Builder
     public function buildSelect()
     {
         $select = $this->getSqlObject()->select($this->getFrom());
+
+        if ($this->hasQuantifier) {
+            $select->quantifier(new \Zend\Db\Sql\Expression('SQL_CALC_FOUND_ROWS'));
+        }
+
         $select->columns($this->getColumns());
         $select->order($this->buildOrder());
 

--- a/src/core/Directus/Database/ResultSet.php
+++ b/src/core/Directus/Database/ResultSet.php
@@ -17,17 +17,22 @@ class ResultSet implements \Iterator, ResultInterface
      */
     protected $fieldCount = null;
 
-    public function __construct($dataSource = null)
+    /**
+     * @var int|null
+     */
+    protected $foundRows = null;
+
+    public function __construct($dataSource = null, $foundRows = null)
     {
         if ($dataSource) {
-            $this->initialize($dataSource);
+            $this->initialize($dataSource, $foundRows);
         }
     }
 
     /**
      * @inheritDoc
      */
-    public function initialize($dataSource)
+    public function initialize($dataSource, $foundRows = null)
     {
         if (is_array($dataSource)) {
             $first = current($dataSource);
@@ -38,6 +43,8 @@ class ResultSet implements \Iterator, ResultInterface
             $this->dataSource = $dataSource;
         }
 
+        $this->foundRows = $foundRows;
+
         return $this;
     }
 
@@ -47,6 +54,14 @@ class ResultSet implements \Iterator, ResultInterface
     public function getFieldCount()
     {
         return $this->dataSource->getFieldCount();
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getFoundRows()
+    {
+        return $this->foundRows;
     }
 
     /**


### PR DESCRIPTION
It took a while but it is finally here.
I used it for weeks and did not notice any kind of bug, please let me know if you find some :)

There is something that I don't like in my code: I had to make `$foundRows` kind of global by adding it to the `BaseTableGateway` class. 

I would have liked to add it to the `ResultSet` and get it from here whenever it is needed (or not). But it seems too complex for me because I didn't know if the `ResultSet` used in Directus was the Directus' one of Zend's one (I would bet on this one). I don't know what these changes could affect.

Could you give me some advice on this? 