### PR TITLE
Remove inactive class as it prevents scrolling

### DIFF
--- a/extensions/core/interfaces/code/code.css
+++ b/extensions/core/interfaces/code/code.css
@@ -43,17 +43,6 @@
 	background: var(--body-background);
 }
 
-.inactive .CodeMirror::before {
-	position: absolute;
-	background-color: var(--dark-gray);
-	opacity: .1;
-	cursor: not-allowed;
-	z-index: 100;
-	width: 100%;
-	height: 100%;
-	content: "";
-}
-
 .CodeMirror pre {
 	padding: 0 10px;
 }

--- a/extensions/core/interfaces/code/input.vue
+++ b/extensions/core/interfaces/code/input.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{ inactive: readonly }" class="interface-code">
+  <div class="interface-code">
     <codemirror
       ref="codemirrorEl"
       :options="cmOptions"


### PR DESCRIPTION
Hi,
      The current implementation of the code interface prevents scrolling when the interface is read-only.  This patch removes the inactive class and relies on setting CodeMirror to readonly alone so users can scroll long code blocks.