### PR TITLE
Add accept option to file inputs to restrict allowed file types

### DIFF
--- a/extensions/core/interfaces/file/input.vue
+++ b/extensions/core/interfaces/file/input.vue
@@ -144,21 +144,13 @@ export default {
         return [];
       }
 
-      const typeFilters = this.options.accept
-        .trim()
-        .split(/,\s*/)
-        .map(type => {
-          if (type.endsWith("/*")) {
-            const value = type.replace(/\*$/, "");
-            return { field: "type", operator: "rlike", value: `${value}%` };
-          } else {
-            return { field: "type", operator: "=", value: type };
-          }
-        });
-
-      return typeFilters.concat([
-        { field: "type", operator: "logical", value: "or" }
-      ]);
+      return [
+        {
+          field: "type",
+          operator: "in",
+          value: this.options.accept.trim().split(/,\s*/)
+        }
+      ];
     }
   },
   methods: {

--- a/extensions/core/interfaces/file/input.vue
+++ b/extensions/core/interfaces/file/input.vue
@@ -22,6 +22,7 @@
       :disabled="readonly"
       class="dropzone"
       @upload="saveUpload"
+      :accept="options.accept"
       :multiple="false"
     ></v-upload>
 
@@ -35,7 +36,7 @@
     <portal to="modal" v-if="newFile">
       <v-modal :title="$t('file_upload')" @close="newFile = false">
         <div class="body">
-          <v-upload @upload="saveUpload" :multiple="false"></v-upload>
+          <v-upload @upload="saveUpload" :accept="options.accept" :multiple="false"></v-upload>
         </div>
       </v-modal>
     </portal>

--- a/extensions/core/interfaces/file/input.vue
+++ b/extensions/core/interfaces/file/input.vue
@@ -129,7 +129,36 @@ export default {
       };
     },
     filters() {
-      return [...this.options.filters, ...this.filtersOverride];
+      return [
+        ...this.options.filters,
+        ...this.fileTypeFilters,
+        ...this.filtersOverride
+      ];
+    },
+    fileTypeFilters() {
+      if (
+        !this.options.accept ||
+        this.filtersOverride.length > 0 ||
+        this.options.filters.some(filter => filter.field === "type")
+      ) {
+        return [];
+      }
+
+      const typeFilters = this.options.accept
+        .trim()
+        .split(/,\s*/)
+        .map(type => {
+          if (type.endsWith("/*")) {
+            const value = type.replace(/\*$/, "");
+            return { field: "type", operator: "like", value: value };
+          } else {
+            return { field: "type", operator: "=", value: type };
+          }
+        });
+
+      return typeFilters.concat([
+        { field: "type", operator: "logical", value: "or" }
+      ]);
     }
   },
   methods: {

--- a/extensions/core/interfaces/file/input.vue
+++ b/extensions/core/interfaces/file/input.vue
@@ -150,7 +150,7 @@ export default {
         .map(type => {
           if (type.endsWith("/*")) {
             const value = type.replace(/\*$/, "");
-            return { field: "type", operator: "like", value: value };
+            return { field: "type", operator: "rlike", value: `${value}%` };
           } else {
             return { field: "type", operator: "=", value: type };
           }

--- a/extensions/core/interfaces/file/meta.json
+++ b/extensions/core/interfaces/file/meta.json
@@ -63,7 +63,7 @@
       "filters": "Filters",
       "filters_comment": "What filters to use",
       "accept": "Accept File Types",
-      "accept_comment": "Limit the field to allow only specific file types"
+      "accept_comment": "Set a list of MIME types that can be picked"
     }
   }
 }

--- a/extensions/core/interfaces/file/meta.json
+++ b/extensions/core/interfaces/file/meta.json
@@ -44,6 +44,11 @@
         "language": "application/json"
       },
       "default": []
+    },
+    "accept": {
+      "name": "$t:accept",
+      "comment": "$t:accept_comment",
+      "interface": "text-input"
     }
   },
   "translation": {
@@ -56,7 +61,9 @@
       "view_query": "View Query",
       "view_query_comment": "Set the view query to use for the files",
       "filters": "Filters",
-      "filters_comment": "What filters to use"
+      "filters_comment": "What filters to use",
+      "accept": "Accept File Types",
+      "accept_comment": "Limit the field to allow only specific file types"
     }
   }
 }

--- a/extensions/core/interfaces/files/input.vue
+++ b/extensions/core/interfaces/files/input.vue
@@ -237,21 +237,13 @@ export default {
         return [];
       }
 
-      const typeFilters = this.options.accept
-        .trim()
-        .split(/,\s*/)
-        .map(type => {
-          if (type.endsWith("/*")) {
-            const value = type.replace(/\*$/, "");
-            return { field: "type", operator: "rlike", value: `${value}%` };
-          } else {
-            return { field: "type", operator: "=", value: type };
-          }
-        });
-
-      return typeFilters.concat([
-        { field: "type", operator: "logical", value: "or" }
-      ]);
+      return [
+        {
+          field: "type",
+          operator: "in",
+          value: this.options.accept.trim().split(/,\s*/)
+        }
+      ];
     }
   },
   methods: {

--- a/extensions/core/interfaces/files/input.vue
+++ b/extensions/core/interfaces/files/input.vue
@@ -221,7 +221,37 @@ export default {
     },
 
     filters() {
-      return [...this.options.filters, ...this.filtersOverride];
+      return [
+        ...this.options.filters,
+        ...this.fileTypeFilters,
+        ...this.filtersOverride
+      ];
+    },
+
+    fileTypeFilters() {
+      if (
+        !this.options.accept ||
+        this.filtersOverride.length > 0 ||
+        this.options.filters.some(filter => filter.field === "type")
+      ) {
+        return [];
+      }
+
+      const typeFilters = this.options.accept
+        .trim()
+        .split(/,\s*/)
+        .map(type => {
+          if (type.endsWith("/*")) {
+            const value = type.replace(/\*$/, "");
+            return { field: "type", operator: "like", value: value };
+          } else {
+            return { field: "type", operator: "=", value: type };
+          }
+        });
+
+      return typeFilters.concat([
+        { field: "type", operator: "logical", value: "or" }
+      ]);
     }
   },
   methods: {

--- a/extensions/core/interfaces/files/input.vue
+++ b/extensions/core/interfaces/files/input.vue
@@ -243,7 +243,7 @@ export default {
         .map(type => {
           if (type.endsWith("/*")) {
             const value = type.replace(/\*$/, "");
-            return { field: "type", operator: "like", value: value };
+            return { field: "type", operator: "rlike", value: `${value}%` };
           } else {
             return { field: "type", operator: "=", value: type };
           }

--- a/extensions/core/interfaces/files/input.vue
+++ b/extensions/core/interfaces/files/input.vue
@@ -3,6 +3,7 @@
     <div v-if="value" class="preview">
       <v-card
         v-for="(file, index) in files"
+        :key="file.id"
         class="card"
         :title="file.title"
         :subtitle="file.subtitle"
@@ -39,7 +40,7 @@
       }"
       :title="$t('file_upload')" @close="newFile = false" @done="newFile = false">
         <div class="body">
-          <v-upload @upload="saveUpload" :multiple="true"></v-upload>
+          <v-upload @upload="saveUpload" :multiple="true" :accept="options.accept"></v-upload>
         </div>
       </v-modal>
     </portal>

--- a/extensions/core/interfaces/files/meta.json
+++ b/extensions/core/interfaces/files/meta.json
@@ -48,6 +48,11 @@
         "language": "application/json"
       },
       "default": []
+    },
+    "accept": {
+      "name": "$t:accept",
+      "comment": "$t:accept_comment",
+      "interface": "text-input"
     }
   },
   "translation": {
@@ -61,6 +66,8 @@
       "view_query_comment": "Set the view query to use for the files",
       "filters": "Filters",
       "filters_comment": "What filters to use",
+      "accept": "Accept File Types",
+      "accept_comment": "Limit the field to allow only specific file types",
       "edit_item": "Edit"
     }
   }

--- a/extensions/core/interfaces/files/meta.json
+++ b/extensions/core/interfaces/files/meta.json
@@ -67,7 +67,7 @@
       "filters": "Filters",
       "filters_comment": "What filters to use",
       "accept": "Accept File Types",
-      "accept_comment": "Limit the field to allow only specific file types",
+      "accept_comment": "Set a list of MIME types that can be picked",
       "edit_item": "Edit"
     }
   }


### PR DESCRIPTION
I had a go at fixing https://github.com/directus/app/issues/727

There are two parts to this:

* Restrict the allowed file types when uploading new files. This is super easy once the `v-upload` component supports an `accept` property
* Restrict the allowed file types when picking existing files. This is complicated and not working properly because as far as I can tell the API doesn't support the same range of options as the HTML file input. The most complicated case would be setting something like `accept="image/*,application/pdf,.doc,.docx"`, which translates to `SELECT * FROM directus_files WHERE type LIKE 'image/%' OR type = 'application/pdf' OR filename LIKE '%.doc' OR filename LIKE '%.docx'`. It looks like the API only supports OR on the same field (not between the `type` and `filename` fields) and doesn't support OR'ing `rlike` and `=` ...

The only solution I can really think of is to stop supporting the full HTML accept syntax and allow only one of: a single wildcard specifier like `image/*`, one or more specific mimetype specifiers like `image/png,application/pdf`, or one or more file extensions like `.png,.pdf` (or even skip that last one and just allow mimetypes for simplicity).

Any thoughts?

Hope you don't mind me opening this not-quite-working PR; I figured it would be easier to discuss the options over some code than try to explain in the issue itself!