### PR TITLE
Small calendar tweaks

### DIFF
--- a/extensions/core/layouts/calendar/layout.vue
+++ b/extensions/core/layouts/calendar/layout.vue
@@ -374,6 +374,7 @@ export default {
   grid-template: repeat(4, 1fr) / repeat(3, 1fr);
   font-size: 0.8em;
   line-height: 1.6em;
+  text-align: center;
 }
 
 #date-months div {

--- a/extensions/core/layouts/calendar/options.vue
+++ b/extensions/core/layouts/calendar/options.vue
@@ -83,7 +83,7 @@ export default {
       var options = {
         __none__: `(${this.$t("dont_show")})`,
         ...this.$lodash.mapValues(this.fields, info =>
-          ["color", "color-palette"].includes(info.interface) ? info.name : null
+          info.type == "string" ? info.name : null
         )
       };
       return this.$lodash.pickBy(options, _.identity);


### PR DESCRIPTION
Hey, due to the small style changes the month select broke a bit:
![grafik](https://user-images.githubusercontent.com/22577866/52786468-31f7ee80-305b-11e9-8c42-38a420108395.png)

And I changed that in the options not only the Color Interface field is allowed but all types of string because maybe you dont want to use the whole color palette but only a few colors and by using a dropdown with preset colors this will now be possible.