### PR TITLE
Readonly for advanced WYSIWYG

### DIFF
--- a/extensions/core/interfaces/wysiwyg-full/input.vue
+++ b/extensions/core/interfaces/wysiwyg-full/input.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="interface-wysiwyg-container" ref="parent">
-    <div ref="editor" class="interface-wysiwyg"></div>
+    <div ref="editor" :class="['interface-wysiwyg', (readonly ? 'readonly' : '')]"></div>
     <portal to="modal" v-if="chooseExisting">
       <v-modal
         :title="$t('choose_one')"
@@ -70,6 +70,7 @@ export default {
 
       this.editor = new Quill(this.$refs.editor, {
         theme: "snow",
+        readOnly: this.readonly,
         modules: {
           toolbar:
             typeof this.options.toolbarOptions === "string"
@@ -183,6 +184,16 @@ export default {
   &:after {
     content: "add_photo_alternate";
     font-size: 20px;
+  }
+}
+
+.ql-editor {
+  &.readonly{
+    background-color: var(--lightest-gray) !important;
+    cursor: not-allowed;
+    &:focus {
+      color: var(--gray);
+    }
   }
 }
 </style>

--- a/extensions/core/interfaces/wysiwyg/input.vue
+++ b/extensions/core/interfaces/wysiwyg/input.vue
@@ -3,7 +3,7 @@
     ref="input"
     :class="[{ fullscreen: distractionFree }, 'interface-wysiwyg-container']"
   >
-    <div ref="editor" class="interface-wysiwyg"></div>
+    <div ref="editor" :class="['interface-wysiwyg', (readonly? 'readonly' : '')]"></div>
     <button
       v-on:click="distractionFree = !distractionFree"
       type="button"
@@ -231,13 +231,14 @@ button.fullscreen-toggle {
         color: var(--accent);
       }
   }
-// where contenteditable attr is NOT present, then show "disabled" styling
-  background-color: var(--lightest-gray);
-  cursor: not-allowed;
-  &:focus {
-    color: var(--gray);
-  }
 
+  &.readonly {
+    background-color: var(--lightest-gray);
+    cursor: not-allowed;
+    &:focus {
+      color: var(--gray);
+    }
+  }
 
   &:-webkit-autofill {
     box-shadow: inset 0 0 0 1000px var(--white) !important;


### PR DESCRIPTION
Adds a gray background to advanced WYSIWYG when set to readonly
Also fixes a cursor:not-allowed showing on divs inside a readable editor