### PR TITLE
Ensure the default date is populated with valid format

### DIFF
--- a/extensions/core/interfaces/datetime/input.vue
+++ b/extensions/core/interfaces/datetime/input.vue
@@ -29,7 +29,7 @@ export default {
   },
   created() {
     if (this.options.defaultToCurrentDatetime && !this.value) {
-      this.$emit("input", new Date());
+      this.$emit("input", format(new Date(), "YYYY-MM-DD HH:mm:ss"));
     }
   },
   methods: {


### PR DESCRIPTION
API does not accept the format generated by `new Date()` fix it by calling the formatter

Fixes #785 