### PR TITLE
Bug fix: Can't upload logo in Global Settings

### DIFF
--- a/src/core/Directus/Services/SettingsService.php
+++ b/src/core/Directus/Services/SettingsService.php
@@ -55,6 +55,11 @@ class SettingsService extends AbstractService
         return $this->itemsService->findAll($this->collection, $params);
     }
 
+    public function findFile($id,array $params = [])
+    {
+        return (new ItemsService($this->container))->findByIds(SchemaManager::COLLECTION_FILES, $id,$params);
+    }
+
     public function findAllFields(array $params = [])
     {
         return (new ItemsService($this->container))->findAll(SchemaManager::COLLECTION_FIELDS, array_merge($params, [


### PR DESCRIPTION
Right now; if the element is M2O then it will return the primary key else return the object.
For the settings table, we have a key-value pair. So the logo key contains the value instead of a relationship.

So for settings table, we will check manually that if it contains any file interface, then get the file object from files table. While updating check the same but replace the object with the primary key.

Currently, we have supported file interface. In the future, we will need to provide for the other relationships too.