### PR TITLE
removed explode()

### DIFF
--- a/src/endpoints/Settings.php
+++ b/src/endpoints/Settings.php
@@ -92,7 +92,7 @@ class Settings extends Route
                     }
                     break;
                 case 'tags':
-                    $inputData['value'] = !empty($responseData['data'][$result]['value']) ? explode($responseData['data'][$result]['value']) : null;
+                    $inputData['value'] = !empty($responseData['data'][$result]['value']) ? $responseData['data'][$result]['value'] : null;
                     break;
             }
         }


### PR DESCRIPTION
removed explode() as missing delimiter produces warnings and $responseData['data'][$result]['value'] already is an array.

This is a follow up to https://github.com/directus/api/issues/624
With 624 closed you now can upload an logo in settings. But when you reload the page you get the above error, which i tried to fix.