### PR TITLE
optional proxy downloads for the project filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ composer.lock
 # This will make sure empty directories has at least one file so it can be tracked by git
 !**/.gitkeep
 /docs/
+
+#Override the PHP internal server rules for static files
+#See https://github.com/slimphp/Slim/issues/1829
+#php -S localhost:8000 cliserver.php
+public/cliserver.php

--- a/public/downloads/.htaccess
+++ b/public/downloads/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule (.*) index.php [L]

--- a/public/downloads/index.php
+++ b/public/downloads/index.php
@@ -1,0 +1,94 @@
+<?php
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Directus\Util\ArrayUtils;
+use Directus\Filesystem\Thumbnailer;
+
+$basePath = realpath(__DIR__ . '/../../');
+// Get Project name
+$projectName = \Directus\get_api_project_from_request();
+
+try {
+    $app = \Directus\create_app_with_project_name($basePath, $projectName);
+} catch (\Exception $e) {
+    http_response_code(404);
+    header('Content-Type: application/json');
+    echo json_encode([
+        'error' => [
+            'error' => 8,
+            'message' => 'API Project Configuration Not Found: ' . $projectName
+        ]
+    ]);
+    exit;
+}
+
+$filesystem = $app->getContainer()->get('filesystem')->getAdapter();
+
+//Remove the project name from the URL
+$path = urldecode(\Directus\get_virtual_path());
+if (substr($path, 0, strlen($projectName)) == $projectName) {
+    $path = substr($path, strlen($projectName));
+}
+
+$settings = \Directus\get_directus_proxy_downloads_settings();
+$timeToLive = \Directus\array_get($settings, 'proxy_downloads_cache_ttl', 86400);
+try {
+
+    //Forward HTTP headers
+    $metadata = $filesystem->getMetadata($path);
+
+    header('HTTP/1.1 200 OK');
+    if (array_key_exists('mimetype', $metadata)) {
+        header('Content-type: ' . $metadata['mimetype']);
+    } else {
+        $mimetype = $filesystem->getMimetype($path);
+        if ($mimetype) {
+            header('Content-type: ' . $mimetype);
+        }
+    }    
+    if (array_key_exists('size', $metadata)) {
+        header('Content-Length: ' . $metadata['size']);
+    } else {
+        $size = $filesystem->getSize($path);
+        if ($size) {
+            header('Content-Length: ' . $size);
+        }
+    }    
+    header("Pragma: cache");
+    header('Cache-Control: max-age=' . $timeToLive);
+    header('Last-Modified: '. gmdate('D, d M Y H:i:s \G\M\T', time()));
+    header('Expires: '. gmdate('D, d M Y H:i:s \G\M\T', time() + $timeToLive));
+
+    //Forward HTTP body
+    $resource = $filesystem->readStream($path);
+    ob_end_flush();
+    fpassthru($resource);
+    exit(0);
+}
+
+catch (Exception $e) {
+    $filePath = ArrayUtils::get($settings, 'proxy_downloads_not_found_location');
+    if (is_string($filePath) && !empty($filePath) && $filePath[0] !== '/') {
+        $filePath = $basePath . '/' . $filePath;
+    }
+
+    // TODO: Throw message if the error is a invalid configuration
+    if (file_exists($filePath)) {
+        $mime = mime_content_type($filePath);
+
+        // TODO: Do we need to cache non-existing files?
+        if ($mime) {
+            header('Content-type: ' . $mime);
+        }
+        header("Pragma: cache");
+        header('Cache-Control: max-age=' . $timeToLive);
+        header('Last-Modified: ' . gmdate('D, d M Y H:i:s \G\M\T', time()));
+        header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', time() + $timeToLive));
+        echo file_get_contents($filePath);
+    } else {
+        http_response_code(404);
+    }
+
+    exit(0);
+}

--- a/src/helpers/file.php
+++ b/src/helpers/file.php
@@ -114,6 +114,7 @@ if (!function_exists('append_storage_information'))
         $container = Application::getInstance()->getContainer();
 
         $config = $container->get('config');
+        $proxyDownloads = $config->get('storage.proxy_downloads');
         $fileRootUrl = $config->get('storage.root_url');
         $hasFileRootUrlHost = parse_url($fileRootUrl, PHP_URL_HOST);
         $isLocalStorageAdapter = $config->get('storage.adapter') == 'local';
@@ -125,11 +126,17 @@ if (!function_exists('append_storage_information'))
 
         foreach ($rows as &$row) {
             $data = [];
-            $data['url'] = $data['full_url'] = $fileRootUrl . '/' . $row['filename'];
 
-            // Add Full url
-            if ($isLocalStorageAdapter && !$hasFileRootUrlHost) {
+            if ($proxyDownloads) {
+                $data['url'] = get_proxy_path($row['filename']);
                 $data['full_url'] = get_url($data['url']);
+            } else {
+                $data['url'] = $data['full_url'] = $fileRootUrl . '/' . $row['filename'];
+
+                // Add Full url
+                if ($isLocalStorageAdapter && !$hasFileRootUrlHost) {
+                    $data['full_url'] = get_url($data['url']);
+                }
             }
 
             // Add Thumbnails
@@ -263,6 +270,27 @@ if (!function_exists('get_thumbnail_path'))
         return sprintf(
             '/thumbnail/%s/%d/%d/%s/%s/%s',
             $projectName, $width, $height, $mode, $quality, $name
+        );
+    }
+}
+
+if (!function_exists('get_proxy_path'))
+{
+    /**
+     * Returns a relative url for the given file pointing to the proxy
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    function get_proxy_path($path)
+    {
+        $projectName = get_api_project_from_request();
+
+        // env/width/height/mode/quality/name
+        return sprintf(
+            '/downloads/%s/%s',
+            $projectName, $path
         );
     }
 }

--- a/src/helpers/settings.php
+++ b/src/helpers/settings.php
@@ -98,6 +98,21 @@ if (!function_exists('get_directus_thumbnail_settings')) {
     }
 }
 
+if (!function_exists('get_directus_proxy_downloads_settings')) {
+    /**
+     * Get all directus files settings
+     *
+     * @return array
+     */
+    function get_directus_proxy_downloads_settings()
+    {
+        return get_directus_settings_by_keys([
+            'proxy_downloads_not_found_location',
+            'proxy_downloads_cache_ttl',
+        ]);
+    }
+}
+
 if (!function_exists('get_directus_settings_by_keys')) {
     /**
      * Get all directus files settings


### PR DESCRIPTION
We have Ceph instances (AMZ S3-compatible storage filesystems) plugged into Directus to manage all our files.

In order to download those files that we've already saved on that storage through Directus, we need to configure the API and specify the ``storage.root_url`` option with the Ceph URLs. In doing so, users are expected to get their files asking the Ceph instances directly. In most corporate environements for instance, those Ceph instances cannot be accessed from the outside world (public networks) and are blocked behind firewalls for security reasons.

In this PR, I've implemented a simple and optional proxy module that can relay the data from the project-defined filesystem to end-users. If ``storage.proxy_downloads`` is set to **true** then all file downloads will be served by this proxy, by default it's not active.

P.S. as a bonus, if you want to test this feature with the internal PHP CLI server and bypass this [bug](https://github.com/slimphp/Slim/issues/1829), here's a [launch script](https://gist.github.com/okayawright/c0eb8a61045a5a145734e8d45e18a47b). Save it inside the *public* folder.