### PR TITLE
Add format endpoint for Thumbnails (Enables WebP Support)

### DIFF
--- a/src/core/Directus/Filesystem/Thumbnail.php
+++ b/src/core/Directus/Filesystem/Thumbnail.php
@@ -16,6 +16,7 @@ class Thumbnail
         'jpeg',
         'gif',
         'png',
+        'webp',
     ];
 
     /**
@@ -89,7 +90,7 @@ class Thumbnail
         }
 
         // Preserve transperancy for gifs and pngs
-        if ($format == 'gif' || $format == 'png') {
+        if ($format == 'gif' || $format == 'png' || $format == 'webp') {
             imagealphablending($imgResized, false);
             imagesavealpha($imgResized, true);
             $transparent = imagecolorallocatealpha($imgResized, 255, 255, 255, 127);
@@ -139,6 +140,9 @@ class Thumbnail
                 break;
             case 'png':
                 imagepng($img, $path);
+                break;
+            case 'webp':
+                imagewebp($img, $path, $quality);
                 break;
             case 'pdf':
             case 'psd':

--- a/src/helpers/file.php
+++ b/src/helpers/file.php
@@ -233,12 +233,13 @@ if (!function_exists('get_thumbnail_url'))
      * @param int $height
      * @param string $mode
      * @param string $quality
+     * @param string $format
      *
      * @return string
      */
-    function get_thumbnail_url($name, $width, $height, $mode = 'crop', $quality = 'good')
+    function get_thumbnail_url($name, $width, $height, $mode = 'crop', $quality = 'good', $format = 'original')
     {
-        return get_url(get_thumbnail_path($name, $width, $height, $mode, $quality));
+        return get_url(get_thumbnail_path($name, $width, $height, $mode, $quality, $format));
     }
 }
 
@@ -252,17 +253,18 @@ if (!function_exists('get_thumbnail_path'))
      * @param int $height
      * @param string $mode
      * @param string $quality
+     * @param string $format
      *
      * @return string
      */
-    function get_thumbnail_path($name, $width, $height, $mode = 'crop', $quality = 'good')
+    function get_thumbnail_path($name, $width, $height, $mode = 'crop', $quality = 'good', $format = 'jpeg')
     {
         $projectName = get_api_project_from_request();
 
         // env/width/height/mode/quality/name
         return sprintf(
-            '/thumbnail/%s/%d/%d/%s/%s/%s',
-            $projectName, $width, $height, $mode, $quality, $name
+            '/thumbnail/%s/%d/%d/%s/%s/%s/%s',
+            $projectName, $width, $height, $mode, $format, $quality, $name
         );
     }
 }

--- a/src/helpers/file.php
+++ b/src/helpers/file.php
@@ -237,7 +237,7 @@ if (!function_exists('get_thumbnail_url'))
      *
      * @return string
      */
-    function get_thumbnail_url($name, $width, $height, $mode = 'crop', $quality = 'good', $format = 'original')
+    function get_thumbnail_url($name, $width, $height, $mode = 'crop', $quality = 'good', $format = 'jpeg')
     {
         return get_url(get_thumbnail_path($name, $width, $height, $mode, $quality, $format));
     }


### PR DESCRIPTION
This PR allows for the endpoint:

`https://[server]/thumbnail/_/[width]/[height]/[action]/[format]/([quality])/[filename]`

While also supporting the original structure of:
`https://[server]/thumbnail/_/[width]/[height]/[action]/([quality])/[filename]`

to maintain backwards compatibility with apps using the API endpoints.

File structure includes a format folder (png, jpeg, etc) between the action and quality/file which defaults to original file's extension.