### PR TITLE
Fixing custom primary key primary key column name

### DIFF
--- a/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -1755,7 +1755,7 @@ class RelationalTableGateway extends BaseTableGateway
                 // $row->getId(); RowGateway perhaps?
                 $relationalColumnId = $row[$relationalColumnName];
                 if (is_array($relationalColumnId) && !empty($relationalColumnId)) {
-                    $relationalColumnId = $relationalColumnId[$tableGateway->primaryKeyFieldName];
+                    $relationalColumnId = $relationalColumnId[$primaryKey];
                 }
 
                 if ($filterFields && !in_array('*', $filterFields)) {


### PR DESCRIPTION
It seems to me that the incorrect variable was being used. The class variable seems to be one level behind in the recursion. I realised that previously in the code a local variable is updated with the correct ID, swapping this variable in seems to resolve the issue.

Very rudimentary testing has been done on this so it will need a lot more testing before being merged.