### PR TITLE
Issue Fix #902

### DIFF
--- a/migrations/upgrades/schemas/20190426156200_set_nullable_value_field_settings_table.php
+++ b/migrations/upgrades/schemas/20190426156200_set_nullable_value_field_settings_table.php
@@ -8,7 +8,7 @@ class SetNullableValueFieldSettingsTable extends AbstractMigration
     {
         $table = $this->table('directus_settings');
 
-        $table->changeColumn('value', 'string', [
+        $table->changeColumn('value', 'text', [
             'null' => true
         ]);
     }

--- a/migrations/upgrades/schemas/20190426156200_set_nullable_value_field_settings_table.php
+++ b/migrations/upgrades/schemas/20190426156200_set_nullable_value_field_settings_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class SetNullableValueFieldSettingsTable extends AbstractMigration
+{
+    public function up()
+    {
+        $table = $this->table('directus_settings');
+
+        $table->changeColumn('value', 'string', [
+            'null' => true
+        ]);
+    }
+}

--- a/src/endpoints/Settings.php
+++ b/src/endpoints/Settings.php
@@ -83,7 +83,7 @@ class Settings extends Route
          * 
          */
         foreach($fieldData['data'] as $key => $value){
-            switch ($value['interface']) {
+            switch ($value['type']) {
                 case 'file':
                     $result = array_search($value['field'], array_column($responseData['data'], 'key'));
                     if($result){
@@ -95,7 +95,7 @@ class Settings extends Route
                         }
                     }
                     break;
-                case 'tags':
+                case 'array':
                     $inputData['value'] = !empty($responseData['data'][$result]['value']) ? $responseData['data'][$result]['value'] : null;
                     break;
             }
@@ -153,13 +153,21 @@ class Settings extends Route
         $inputData = $request->getParsedBody();
         foreach($fieldData['data'] as $key => $value){
             if($value['field'] == $setting){
-                switch ($value['interface']) {
-                    case 'file':
-                        $inputData['value'] = isset($inputData['value']['id']) ? $inputData['value']['id'] : $inputData['value'];
-                        break;
-                    case 'tags':
-                        $inputData['value'] = is_array($inputData['value']) ? implode(",",$inputData['value']) : $inputData['value'];
-                        break;
+                if($inputData['value'] != null){
+                    switch ($value['type']) {
+                        case 'file':
+                            $inputData['value'] = isset($inputData['value']['id']) ? $inputData['value']['id'] : $inputData['value'];
+                            break;
+                        case 'array':
+                            $inputData['value'] = is_array($inputData['value']) ? implode(",",$inputData['value']) : $inputData['value'];
+                            break;
+                        case 'json':
+                            $inputData['value'] = json_encode($inputData['value']);
+                            break;
+                    }
+                }else{
+                    // To convert blank string in null
+                    $inputData['value'] = null;
                 }
             }
         }
@@ -174,8 +182,6 @@ class Settings extends Route
      */
     public function update(Request $request, Response $response)
     {
-        $this->validateRequestPayload($request);
-
         $payload = $request->getParsedBody();
         $id = $request->getAttribute('id');
 
@@ -199,6 +205,7 @@ class Settings extends Route
          * Get the interface based input
          * 
          */
+    
         $inputData = $this->getInterfaceBasedInput($request,$serviceData['data']['key']);
         $responseData = $service->update(
             $request->getAttribute('id'),


### PR DESCRIPTION
Ability to reset/remove global settings. If the field is left blank, `NULL` will be returned instead of a blank string. The settings field was not nullable so included a migration file to change it.
Also, added support for datatypes like `Array` and `JSON` to save values.
