### PR TITLE
Increase expiry time of tokens from 5 to 20 minutes

### DIFF
--- a/src/core/Directus/Authentication/Provider.php
+++ b/src/core/Directus/Authentication/Provider.php
@@ -71,7 +71,7 @@ class Provider
             throw new Exception('auth: secret key is required and it must be a string');
         }
 
-        $ttl = ArrayUtils::get($options, 'ttl', 5);
+        $ttl = ArrayUtils::get($options, 'ttl', 20);
         if (!is_numeric($ttl)) {
             throw new Exception('ttl must be a number');
         }


### PR DESCRIPTION
It should still be pretty secure. This allows the app to go easier on
the refreshing, and it makes sure that you can upload large files
without having the token expire halfway through.