### PR TITLE
Issue Fix #920

### DIFF
--- a/src/core/Directus/Console/Common/User.php
+++ b/src/core/Directus/Console/Common/User.php
@@ -28,6 +28,28 @@ class User
     }
 
     /**
+     * Check the existance of user in the system
+     * 
+     * The function will check the user of given their e-mail address exist in 
+     * the system or not.
+     */
+    public function userExists($email)
+    {
+        try {
+            $rowset = $this->usersTableGateway->select([
+                'email' => $email
+            ]);
+            if ($rowset->count() > 0) {
+                return true;
+            }
+            return false;
+        } catch (\PDOException $ex) {
+            return false;
+        }
+    }
+
+
+    /**
      *  Change the password of a user given their e-mail address
      *
      *  The function will change the password of a user given their e-mail

--- a/src/core/Directus/Console/Modules/InstallModule.php
+++ b/src/core/Directus/Console/Modules/InstallModule.php
@@ -201,12 +201,17 @@ class InstallModule extends ModuleBase
                 $user = new User($directus_path);
                 try {
                     $hasEmail = ArrayUtils::has($data, 'user_email');
-                    if ($hasEmail) {
-                        $user->changeEmail(1, $data['user_email']);
-                    }
+                    if ($hasEmail && !$user->userExists($data['user_email'])) {
+                        InstallerUtils::addDefaultUser($directus_path, $data, $projectName);
+                    }else{
+                        //TODO: Verify this method is required or not! 
+                        if ($hasEmail) {
+                            $user->changeEmail(1, $data['user_email']);
+                        }
 
-                    if ($hasEmail && ArrayUtils::has($data, 'user_password')) {
-                        $user->changePassword($data['user_email'], $data['user_password']);
+                        if ($hasEmail && ArrayUtils::has($data, 'user_password')) {
+                            $user->changePassword($data['user_email'], $data['user_password']);
+                        }
                     }
                 } catch (UserUpdateException $ex) {
                     throw new CommandFailedException('Error changing admin e-mail' . ': ' . $ex->getMessage());


### PR DESCRIPTION
The initial user was not created by default (User with `id` 1) and the current code tries to update the entry with the `id` 1. We need to check if the user with the given email exists.
