### PR TITLE
added collection/table to InvalidFieldException

### DIFF
--- a/src/core/Directus/Database/Exception/InvalidFieldException.php
+++ b/src/core/Directus/Database/Exception/InvalidFieldException.php
@@ -8,9 +8,9 @@ class InvalidFieldException extends UnprocessableEntityException
 {
     const ERROR_CODE = 202;
 
-    public function __construct($field)
+    public function __construct($field, $collection)
     {
-        $message = sprintf('Invalid field "%s"', $field);
+        $message = sprintf('Invalid field "%s" in "%s"', $field, $collection);
 
         parent::__construct($message);
     }

--- a/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -1318,7 +1318,7 @@ class RelationalTableGateway extends BaseTableGateway
         );
 
         if (!$field) {
-            throw new Exception\InvalidFieldException($fieldName);
+            throw new Exception\InvalidFieldException($fieldName, $table);
         }
 
         $condition = $this->parseCondition($condition);
@@ -1587,7 +1587,7 @@ class RelationalTableGateway extends BaseTableGateway
 
             $field = SchemaService::getField($this->table, $orderBy, false, $this->acl === null);
             if ($orderBy !== '?' && !$field) {
-                throw new Exception\InvalidFieldException($column);
+                throw new Exception\InvalidFieldException($column, $this->table);
             }
 
             if ($field && $field->isAlias()) {
@@ -2048,7 +2048,7 @@ class RelationalTableGateway extends BaseTableGateway
 
         foreach ($selectedFields as $field) {
             if (!$collection->hasField($field)) {
-                throw new Exception\InvalidFieldException($field);
+                throw new Exception\InvalidFieldException($field, $collection->getName());
             }
         }
     }

--- a/src/core/Directus/Services/TablesService.php
+++ b/src/core/Directus/Services/TablesService.php
@@ -1683,7 +1683,7 @@ class TablesService extends AbstractService
             foreach ($sort as $field) {
                 $field = (string)$field;
                 if (!$collection->hasField($field)) {
-                    throw new InvalidFieldException($field);
+                    throw new InvalidFieldException($field, $collection->getName());
                 }
             }
         }


### PR DESCRIPTION
This PR adds the collection/table name to InvalidFieldException.

I find it very hard to find errors made in a "fields" definition, if only the field name is shown. Fields like "created_by" or "status" for example may be used multiple times. By adding the collection/table name to the exception message it is a lot easier to find errors in the definition.