### PR TITLE
reuse item service instead of using a new instance

### DIFF
--- a/src/core/Directus/Services/SettingsService.php
+++ b/src/core/Directus/Services/SettingsService.php
@@ -57,12 +57,12 @@ class SettingsService extends AbstractService
 
     public function findFile($id,array $params = [])
     {
-        return (new ItemsService($this->container))->findByIds(SchemaManager::COLLECTION_FILES, $id,$params);
+        return $this->itemsService->findByIds(SchemaManager::COLLECTION_FILES, $id,$params);
     }
 
     public function findAllFields(array $params = [])
     {
-        return (new ItemsService($this->container))->findAll(SchemaManager::COLLECTION_FIELDS, array_merge($params, [
+        return $this->itemsService->findAll(SchemaManager::COLLECTION_FIELDS, array_merge($params, [
             'filter' => [
                 'collection' => $this->collection
             ]


### PR DESCRIPTION
I found that while fetching the logo and the fields in SettingsService a new instance of the ItemsService is used. But the ItemsService is also created during object construction and available.

So i refactored this to use the existing service. If there is no perticular reason to create a new instance i dont know of this should improve performance a litte.