### PR TITLE
Issue fix #917

### DIFF
--- a/src/core/Directus/Application/Http/Middleware/CorsMiddleware.php
+++ b/src/core/Directus/Application/Http/Middleware/CorsMiddleware.php
@@ -37,7 +37,7 @@ class CorsMiddleware extends AbstractMiddleware
             'Authorization',
         ],
         'exposed_headers' => [],
-        'max_age' => null,
+        'max_age' => 500,
         'credentials' => false,
     ];
 


### PR DESCRIPTION
Set default value of `max_age` for general API