### PR TITLE
enables custom logo from directus_files when permissions on directus_files are set to mine or role

### DIFF
--- a/src/core/Directus/Services/ItemsService.php
+++ b/src/core/Directus/Services/ItemsService.php
@@ -101,7 +101,9 @@ class ItemsService extends AbstractService
         $ids = StringUtils::safeCvs($ids, false, false);
 
         try {
-            $this->getAcl()->enforceRead($collection, $statusValue);
+            if (false !== $acl) {
+                $this->getAcl()->enforceRead($collection, $statusValue);
+            }
         } catch (ForbiddenCollectionReadException $e) {
             if (is_array($ids) && count($ids) > 1) {
                 throw $e;

--- a/src/core/Directus/Services/ItemsService.php
+++ b/src/core/Directus/Services/ItemsService.php
@@ -101,6 +101,8 @@ class ItemsService extends AbstractService
         $ids = StringUtils::safeCvs($ids, false, false);
 
         try {
+            // if acl check is disabled (e.g. fetching the logo from the settings endpoint/service) do not
+            // enforce permissions here!
             if (false !== $acl) {
                 $this->getAcl()->enforceRead($collection, $statusValue);
             }

--- a/src/core/Directus/Services/ItemsService.php
+++ b/src/core/Directus/Services/ItemsService.php
@@ -85,18 +85,19 @@ class ItemsService extends AbstractService
      * @param string $collection
      * @param mixed $ids
      * @param array $params
+     * @params bool $acl default true
      *
      * @return array
      *
      * @throws ItemNotFoundException
      * @throws ForbiddenCollectionReadException
      */
-    public function findByIds($collection, $ids, array $params = [])
+    public function findByIds($collection, $ids, array $params = [], $acl = true)
     {
         $params = ArrayUtils::omit($params, static::SINGLE_ITEM_PARAMS_BLACKLIST);
 
         $statusValue = $this->getStatusValue($collection, $ids);
-        $tableGateway = $this->createTableGateway($collection);
+        $tableGateway = $this->createTableGateway($collection, $acl);
         $ids = StringUtils::safeCvs($ids, false, false);
 
         try {

--- a/src/core/Directus/Services/SettingsService.php
+++ b/src/core/Directus/Services/SettingsService.php
@@ -57,7 +57,8 @@ class SettingsService extends AbstractService
 
     public function findFile($id,array $params = [])
     {
-        return $this->itemsService->findByIds(SchemaManager::COLLECTION_FILES, $id,$params);
+        $noAcl = false;
+        return $this->itemsService->findByIds(SchemaManager::COLLECTION_FILES, $id,$params, $noAcl);
     }
 
     public function findAllFields(array $params = [])


### PR DESCRIPTION
pass the acl flag for the tableGateway factory from the settings endpoint to fetch a logo from directus_files even when the permissions are set to "mine" or "role".

The TableGateway already supports the circumvention of the acl. As the SessingsService uses the ItemService to fetch the logo i passthru an additional parameter to findByIds(). 

As you have to have the ID to fetch data i dont think this creates a security issue. Default the acl is in place, but if you have some ids (from settings for example) and want to fetch this items and ignore acl you now can do that.

The alternative in my opinion would be to have the custom logo as url instead of a directus_file.