### PR TITLE
Fix Invite User Feature

### DIFF
--- a/src/core/Directus/Services/UsersService.php
+++ b/src/core/Directus/Services/UsersService.php
@@ -13,6 +13,7 @@ use Directus\Database\TableGateway\DirectusUsersTableGateway;
 use Directus\Database\TableGateway\RelationalTableGateway;
 use Directus\Exception\ForbiddenException;
 use Directus\Exception\ForbiddenLastAdminException;
+use Directus\Permissions\Acl;
 use Directus\Util\ArrayUtils;
 use Directus\Util\DateTimeUtils;
 use Directus\Util\JWTUtils;
@@ -260,6 +261,18 @@ class UsersService extends AbstractService
             throw new InvalidTokenException();
         }
 
+        // auth middleware doesn't parse this kind of token
+        // but we know that only admins can send invitations
+        $this->getAcl()->setUserId($payload->sender);
+        $this->getAcl()->setPermissions([
+            'directus_users' => [
+                [
+                    Acl::ACTION_READ   => Acl::LEVEL_FULL,
+                    Acl::ACTION_UPDATE => Acl::LEVEL_FULL,
+                ],
+            ],
+        ]);
+
         $auth = $this->getAuth();
         $auth->validatePayloadOrigin($payload);
 
@@ -267,7 +280,6 @@ class UsersService extends AbstractService
         try {
             $result = $this->findOne([
                 'filter' => [
-                    'id' => $payload->id,
                     'email' => $payload->email,
                     'status' => DirectusUsersTableGateway::STATUS_INVITED
                 ]

--- a/src/core/Directus/Services/UsersService.php
+++ b/src/core/Directus/Services/UsersService.php
@@ -217,7 +217,7 @@ class UsersService extends AbstractService
             $datetime = DateTimeUtils::nowInUTC();
             $invitationToken = $auth->generateInvitationToken([
                 'date' => $datetime->toString(),
-                'exp' => $datetime->inDays(30)->toString(),
+                'exp' => $datetime->inDays(30)->getTimestamp(),
                 'email' => $email,
                 'sender' => $this->getAcl()->getUserId()
             ]);

--- a/src/endpoints/Users.php
+++ b/src/endpoints/Users.php
@@ -207,11 +207,9 @@ class Users extends Route
      */
     public function acceptInvitation(Request $request, Response $response)
     {
-        $this->validateRequestPayload($request);
-
         $service = new UsersService($this->container);
         $responseData = $service->enableUserWithInvitation(
-            $request->getParsedBodyParam('token')
+            $request->getAttribute('token')
         );
 
         return $this->responseWithData($request, $response, $responseData);

--- a/src/endpoints/Users.php
+++ b/src/endpoints/Users.php
@@ -25,7 +25,7 @@ class Users extends Route
         $app->post('', [$this, 'create']);
         $app->get('/{id}', [$this, 'read']);
         $app->post('/invite', [$this, 'invite']);
-        $app->post('/invite/{token}', [$this, 'acceptInvitation']);
+        $app->map(['GET', 'POST'], '/invite/{token}', [$this, 'acceptInvitation']);
         $app->patch('/{id}', [$this, 'update']);
         $app->delete('/{id}', [$this, 'delete']);
 

--- a/src/mail/user-invitation.twig
+++ b/src/mail/user-invitation.twig
@@ -3,7 +3,7 @@
 
 <p>You have been invited to {{settings.project_name }}. Please click the link below to join:</p>
 
-{% set invitation_url = settings.project_url|trim('/') ~ '/' ~ api.project ~ '/auth/invitation/' ~ token %}
+{% set invitation_url = settings.project_url|trim('/') ~ '/' ~ api.project ~ '/users/invite/' ~ token %}
 <p><a href="{{ invitation_url }}">{{ invitation_url }}</a></p>
 
 <p>Love,<br>Directus</p>


### PR DESCRIPTION
I'm not sure about that authorization approach, but it works so far:

https://github.com/ybelenko/api/blob/ac98c1c8a6652607c20f0a45d705eac6426daba2/src/core/Directus/Services/UsersService.php#L264-L274

I'm also not sure that you want invitation link to be mapped directly to `acceptInvitation` API endpoint.

Method `sendInvitationTo` still ignores existing users, I didn't fix it.

Accordingly to `composer.json` you have no php linters, so I hope that my PR meets your coding styles.

Fixes #989 