### PR TITLE
Add file 'format' query parameter to Thumbnail URLs

### DIFF
--- a/public/thumbnail/index.php
+++ b/public/thumbnail/index.php
@@ -26,12 +26,16 @@ try {
 $settings = \Directus\get_directus_thumbnail_settings();
 $timeToLive = \Directus\array_get($settings, 'thumbnail_cache_ttl', 86400);
 try {
+
+    parse_str($_SERVER['QUERY_STRING'], $queryParams);
+
     // if the thumb already exists, return it
     $thumbnailer = new Thumbnailer(
         $app->getContainer()->get('filesystem'),
         $app->getContainer()->get('filesystem_thumb'),
         $settings,
-        urldecode(\Directus\get_virtual_path())
+        urldecode(\Directus\get_virtual_path()),
+        $queryParams
     );
 
     $image = $thumbnailer->get();

--- a/src/core/Directus/Filesystem/Thumbnail.php
+++ b/src/core/Directus/Filesystem/Thumbnail.php
@@ -16,6 +16,7 @@ class Thumbnail
         'jpeg',
         'gif',
         'png',
+	    'webp'
     ];
 
     /**
@@ -89,7 +90,7 @@ class Thumbnail
         }
 
         // Preserve transperancy for gifs and pngs
-        if ($format == 'gif' || $format == 'png') {
+        if ($format == 'gif' || $format == 'png' || $format == 'webp') {
             imagealphablending($imgResized, false);
             imagesavealpha($imgResized, true);
             $transparent = imagecolorallocatealpha($imgResized, 255, 255, 255, 127);
@@ -139,6 +140,9 @@ class Thumbnail
                 break;
             case 'png':
                 imagepng($img, $path);
+                break;
+	        case 'webp':
+                imagewebp($img, $path, $quality);
                 break;
             case 'pdf':
             case 'psd':

--- a/src/core/Directus/Filesystem/Thumbnailer.php
+++ b/src/core/Directus/Filesystem/Thumbnailer.php
@@ -263,7 +263,7 @@ class Thumbnailer {
         // Set thumbnail filename parameters
         $thumbnailParams['fileExt'] = $ext;
         $thumbnailParams['fileName'] = $filename;
-        $format = ArrayUtils::get($this->params, 'format') ?: $ext;
+        $format = strtolower(ArrayUtils::get($this->params, 'format') ?: $ext);
 
         if (! $this->isSupportedFileExtension($format)) {
             throw new Exception('Invalid file format.');
@@ -272,9 +272,9 @@ class Thumbnailer {
         // Check format against image extension
         if(
             $format !== NULL &&
-            strtolower($ext) !== strtolower($format) &&
+            strtolower($ext) !== $format &&
             !(
-                (strtolower($format) === 'jpeg' || strtolower($format) === 'jpg') &&
+                ($format === 'jpeg' || $format === 'jpg') &&
                 (strtolower($ext) === 'jpeg' || strtolower($ext) === 'jpg')
             )
         ) {

--- a/src/core/Directus/Filesystem/Thumbnailer.php
+++ b/src/core/Directus/Filesystem/Thumbnailer.php
@@ -270,7 +270,7 @@ class Thumbnailer {
         }
 
         if($format !== NULL && strtolower($ext) !== strtolower($format)) {
-            $thumbnailParams['thumbnailFileName'] = $filename . '.' . 'webp';
+            $thumbnailParams['thumbnailFileName'] = $filename . '.' . $format;
         } else {
             $thumbnailParams['thumbnailFileName'] = $filename;
         }

--- a/src/core/Directus/Filesystem/Thumbnailer.php
+++ b/src/core/Directus/Filesystem/Thumbnailer.php
@@ -278,7 +278,7 @@ class Thumbnailer {
                 (strtolower($ext) === 'jpeg' || strtolower($ext) === 'jpg')
             )
         ) {
-            $thumbnailParams['thumbnailFileName'] = $filename . '.' . $format;
+            $thumbnailParams['thumbnailFileName'] = $name . '.' . $format;
         } else {
             $thumbnailParams['thumbnailFileName'] = $filename;
         }

--- a/src/core/Directus/Filesystem/Thumbnailer.php
+++ b/src/core/Directus/Filesystem/Thumbnailer.php
@@ -49,13 +49,14 @@ class Thumbnailer {
      *
      * @throws Exception
      */
-    public function __construct(Filesystem $main, Filesystem $thumb, array $config, $path = '')
+    public function __construct(Filesystem $main, Filesystem $thumb, array $config, $path = '', array $params)
     {
         try {
             // $this->files = $files;
             $this->filesystem = $main;
             $this->filesystemThumb = $thumb;
             $this->config = $config;
+            $this->params = $params;
 
             $this->thumbnailParams = $this->extractThumbnailParams($path);
 
@@ -106,8 +107,8 @@ class Thumbnailer {
     public function get()
     {
         try {
-            if( $this->filesystemThumb->exists($this->thumbnailDir . '/' . $this->fileName) ) {
-                $img = $this->filesystemThumb->read($this->thumbnailDir . '/' . $this->fileName);
+            if( $this->filesystemThumb->exists($this->thumbnailDir . '/' . $this->thumbnailFileName) ) {
+                $img = $this->filesystemThumb->read($this->thumbnailDir . '/' . $this->thumbnailFileName);
             }
 
             return isset($img) && $img ? $img : null;
@@ -127,8 +128,11 @@ class Thumbnailer {
     public function getThumbnailMimeType()
     {
         try {
-            if( $this->filesystemThumb->exists($this->thumbnailDir . '/' . $this->fileName) ) {
-                $img = Image::make($this->filesystemThumb->read($this->thumbnailDir . '/' . $this->fileName));
+            if( $this->filesystemThumb->exists($this->thumbnailDir . '/' . $this->thumbnailFileName) ) {
+                if(strtolower(pathinfo($this->thumbnailFileName, PATHINFO_EXTENSION)) === 'webp') {
+                    return 'image/webp';
+                }
+                $img = Image::make($this->filesystemThumb->read($this->thumbnailDir . '/' . $this->thumbnailFileName));
                 return $img->mime();
             }
 
@@ -166,8 +170,8 @@ class Thumbnailer {
                 $img->resizeCanvas($this->width, $this->height, ArrayUtils::get($options, 'position', 'center'), ArrayUtils::get($options, 'resizeRelative', false), ArrayUtils::get($options, 'canvasBackground', [255, 255, 255, 0]));
             }
 
-            $encodedImg = (string) $img->encode(ArrayUtils::get($this->thumbnailParams, 'fileExt'), ($this->quality ? $this->translateQuality($this->quality) : null));
-            $this->filesystemThumb->write($this->thumbnailDir . '/' . $this->fileName, $encodedImg);
+            $encodedImg = (string) $img->encode($this->format, ($this->quality ? $this->translateQuality($this->quality) : null));
+            $this->filesystemThumb->write($this->thumbnailDir . '/' . $this->thumbnailFileName, $encodedImg);
 
             return $encodedImg;
         }
@@ -197,8 +201,8 @@ class Thumbnailer {
             // resize/crop image
             $img->fit($this->width, $this->height, function($constraint){}, ArrayUtils::get($options, 'position', 'center'));
 
-            $encodedImg = (string) $img->encode(ArrayUtils::get($this->thumbnailParams, 'fileExt'), ($this->quality ? $this->translateQuality($this->quality) : null));
-            $this->filesystemThumb->write($this->thumbnailDir . '/' . $this->fileName, $encodedImg);
+            $encodedImg = (string) $img->encode($this->format, ($this->quality ? $this->translateQuality($this->quality) : null));
+            $this->filesystemThumb->write($this->thumbnailDir . '/' . $this->thumbnailFileName, $encodedImg);
 
             return $encodedImg;
         }
@@ -257,8 +261,19 @@ class Thumbnailer {
         }
 
         // Set thumbnail filename parameters
-        $thumbnailParams['fileName'] = $filename;
         $thumbnailParams['fileExt'] = $ext;
+        $thumbnailParams['fileName'] = $filename;
+        $format = ArrayUtils::get($this->params, 'format') ?: $ext;
+
+        if (! $this->isSupportedFileExtension($format)) {
+            throw new Exception('Invalid file format.');
+        }
+
+        if($format !== NULL && strtolower($ext) !== strtolower($format)) {
+            $thumbnailParams['thumbnailFileName'] = $filename . '.' . 'webp';
+        } else {
+            $thumbnailParams['thumbnailFileName'] = $filename;
+        }
 
         return $thumbnailParams;
     }

--- a/src/core/Directus/Filesystem/Thumbnailer.php
+++ b/src/core/Directus/Filesystem/Thumbnailer.php
@@ -269,7 +269,15 @@ class Thumbnailer {
             throw new Exception('Invalid file format.');
         }
 
-        if($format !== NULL && strtolower($ext) !== strtolower($format)) {
+        // Check format against image extension
+        if(
+            $format !== NULL &&
+            strtolower($ext) !== strtolower($format) &&
+            !(
+                (strtolower($format) === 'jpeg' || strtolower($format) === 'jpg') &&
+                (strtolower($ext) === 'jpeg' || strtolower($ext) === 'jpg')
+            )
+        ) {
             $thumbnailParams['thumbnailFileName'] = $filename . '.' . $format;
         } else {
             $thumbnailParams['thumbnailFileName'] = $filename;


### PR DESCRIPTION
Allows for thumbnailing of different formats from source image (like webp!) via:

`[thumbnail_url]?format=[format]`

Easy peasy lemon squeezy!