### PR TITLE
Remove related column only for M2O

### DIFF
--- a/src/core/Directus/Services/TablesService.php
+++ b/src/core/Directus/Services/TablesService.php
@@ -760,8 +760,9 @@ class TablesService extends AbstractService
             /**
              * Remove O2M field if M2O interface deleted as O2M will only work if M2O exist
              */
-            $this->removeRelatedColumnInfo($columnObject);
-
+            if($columnObject->isManyToOne()){
+              $this->removeRelatedColumnInfo($columnObject);
+            }
             $this->removeColumnInfo($collectionName, $fieldName);
         }
     }


### PR DESCRIPTION
Delete a field from collection throws an error of internal server error as every time it tries to remove all the related columns which need to be only for M2O.