### PR TITLE
FEAT sensible default values in the configuration file for memcache(d)

### DIFF
--- a/config/api_sample.php
+++ b/config/api_sample.php
@@ -41,9 +41,16 @@ return [
         // ],
         // 'pool' => [
         //    'adapter'   => 'memcached',
+        //    //'url' => 'localhost:11211;localhost:11212'
         //    'host'      => 'localhost',
         //    'port'      => 11211
         // ],
+        // 'pool' => [
+        //    'adapter'   => 'memcache',
+        //    'url' => 'localhost:11211;localhost:11212'
+        //    //'host'      => 'localhost',
+        //    //'port'      => 11211
+        //],        
         // 'pool' => [
         //    'adapter'   => 'redis',
         //    'host'      => 'localhost',

--- a/src/core/Directus/Util/Installation/stubs/config.stub
+++ b/src/core/Directus/Util/Installation/stubs/config.stub
@@ -47,9 +47,16 @@ return [
         // ],
         // 'pool' => [
         //    'adapter'   => 'memcached',
+        //    //'url' => 'localhost:11211;localhost:11212'
         //    'host'      => 'localhost',
         //    'port'      => 11211
         // ],
+        // 'pool' => [
+        //    'adapter'   => 'memcache',
+        //    'url' => 'localhost:11211;localhost:11212'
+        //    //'host'      => 'localhost',
+        //    //'port'      => 11211
+        // ],        
         // 'pool' => [
         //    'adapter'   => 'redis',
         //    'host'      => 'localhost',


### PR DESCRIPTION
Add default values in api_sample.php and in the auto-generated api.php files for helping users to configure their memcache or memcached clusters