### PR TITLE
Add lang parameters in GraphQL user collections.

### DIFF
--- a/src/core/Directus/GraphQL/Collection/CollectionList.php
+++ b/src/core/Directus/GraphQL/Collection/CollectionList.php
@@ -12,6 +12,7 @@ class CollectionList
     protected $limit;
     protected $offset;
     protected $container;
+    protected $lang;
 
     public function __construct()
     {
@@ -20,6 +21,7 @@ class CollectionList
         $this->limit = ['limit' => Types::int()];
         $this->offset = ['offset' => Types::int()];
         $this->container = Application::getInstance()->getContainer();
+        $this->lang = ['lang' => Types::string()];
     }
 
     protected function convertArgsToFilter($args)

--- a/src/core/Directus/GraphQL/Collection/UserCollectionList.php
+++ b/src/core/Directus/GraphQL/Collection/UserCollectionList.php
@@ -25,11 +25,10 @@ class UserCollectionList extends CollectionList
             if ($value['managed']) {
 
                 $type = Types::userCollection($value['collection']);
-
                 //Add the list of collection
                 $this->list[$value['collection']] = [
                     'type' => Types::collections($type),
-                    'args' => array_merge($this->id, $this->limit, $this->offset, ['filter' => Types::filters($value['collection'])]),
+                    'args' => array_merge($this->id, $this->limit, $this->offset, $this->lang, ['filter' => Types::filters($value['collection'])]),
                     'resolve' => function ($val, $args, $context, ResolveInfo $info) use ($value, $itemsService) {
                         $itemsService->throwErrorIfSystemTable($value['collection']);
                         $responseData = [];


### PR DESCRIPTION
Fix #1110 

Now GraphQL query can use lang parameter for filter user collections by
languages, the changes are reflected in the schema.