### PR TITLE
Add cache for GraphQL content

### DIFF
--- a/src/core/Directus/Application/Http/Middleware/ResponseCacheMiddleware.php
+++ b/src/core/Directus/Application/Http/Middleware/ResponseCacheMiddleware.php
@@ -5,6 +5,7 @@ namespace Directus\Application\Http\Middleware;
 use Directus\Cache\Response as CacheResponse;
 use Directus\Application\Http\Request;
 use Directus\Application\Http\Response;
+use Directus\Util\StringUtils;
 
 class ResponseCacheMiddleware extends AbstractMiddleware
 {
@@ -33,6 +34,11 @@ class ResponseCacheMiddleware extends AbstractMiddleware
             $requestPath = $request->getUri()->getPath();
 
             $key = md5($container->get('acl')->getUserId().'@'.$requestPath.'?'.http_build_query($parameters));
+        } else if ($request->isPost() && StringUtils::endsWith($request->getUri()->getPath(), '/gql')) {
+            // Handle caching for GraphQL query that are POST.
+            $body = $request->getBody();
+            $key = md5($body->getContents());
+            $body->rewind();
         } else {
             $key = null;
         }

--- a/src/core/Directus/Application/Http/Middleware/ResponseCacheMiddleware.php
+++ b/src/core/Directus/Application/Http/Middleware/ResponseCacheMiddleware.php
@@ -36,6 +36,7 @@ class ResponseCacheMiddleware extends AbstractMiddleware
             $key = md5($container->get('acl')->getUserId().'@'.$requestPath.'?'.http_build_query($parameters));
         } else if ($request->isPost() && StringUtils::endsWith($request->getUri()->getPath(), '/gql')) {
             // Handle caching for GraphQL query that are POST.
+            // TODO:: Add support for ACL and Mutation
             $body = $request->getBody();
             $key = md5($body->getContents());
             $body->rewind();


### PR DESCRIPTION
Directus only cache content that coming from a GET request, this behavior
works well for REST but GraphQL put the payload of a query in the body
encoded as JSON.

This is a temporary workaround, in fact, the cache doesn't consider ACL
and mutation but this really make usable GraphQL integration, because
without this is really slow (above 1.5 seconds) for a simple query.

Consider this an MVP through full GraphQL implementation in Directus.

It's just a suggestion for usability I don't bother if you discard this!