### PR TITLE
Disable error reporting until known configuration

### DIFF
--- a/src/core/Directus/Application/Application.php
+++ b/src/core/Directus/Application/Application.php
@@ -142,7 +142,7 @@ class Application extends App
     protected function createConfig(array $appConfig)
     {
         return [
-            'settings' => $appConfig['settings'],
+            'settings' => isset($appConfig['settings']) ? $appConfig['settings'] : [],
             'config' => function () use ($appConfig) {
                 return new Config($appConfig);
             }

--- a/src/web.php
+++ b/src/web.php
@@ -8,6 +8,11 @@ $basePath =  realpath(__DIR__ . '/../');
 
 require $basePath . '/vendor/autoload.php';
 
+// Disable error reporting until we know which kind of
+// environment we're in (development, production)
+error_reporting(0);
+ini_set('display_errors', 0);
+
 // Creates a simple endpoint to test the server rewriting
 // If the server responds "pong" it means the rewriting works
 // NOTE: The API requires the default project to be configured to properly works

--- a/src/web.php
+++ b/src/web.php
@@ -8,11 +8,6 @@ $basePath =  realpath(__DIR__ . '/../');
 
 require $basePath . '/vendor/autoload.php';
 
-// Disable error reporting until we know which kind of
-// environment we're in (development, production)
-error_reporting(0);
-ini_set('display_errors', 0);
-
 // Creates a simple endpoint to test the server rewriting
 // If the server responds "pong" it means the rewriting works
 // NOTE: The API requires the default project to be configured to properly works


### PR DESCRIPTION
This disableds error reporting until we know which environment we're in, and sets default value for user settings