### PR TITLE
Fixed possible null pointer exception in fetchItems when no ACL is used

### DIFF
--- a/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -1208,7 +1208,7 @@ class RelationalTableGateway extends BaseTableGateway
             }, $results);
         }
 
-        if ($statusField && $this->acl->getCollectionStatuses($this->table)) {
+        if ($statusField && $this->acl != null && $this->acl->getCollectionStatuses($this->table)) {
             foreach ($results as $index => &$item) {
                 $statusId = ArrayUtils::get($item, $statusField->getName());
                 $blacklist = $this->acl->getReadFieldBlacklist($this->table, $statusId);


### PR DESCRIPTION
Fixed an issue, that fetchItems raises a null pointer exception on when a table gateway with no ACL is used (set to 'false'). `$this->acl` is null in this case, subsequently `$this->acl->getCollectionStatuses($this->table)` throws an exception.