### PR TITLE
create thumb for pdf if imagick is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@directus/api",
   "private": true,
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Directus API",
   "main": "index.js",
   "repository": "directus/api",

--- a/src/core/Directus/Application/Application.php
+++ b/src/core/Directus/Application/Application.php
@@ -13,7 +13,7 @@ class Application extends App
      *
      * @var string
      */
-    const DIRECTUS_VERSION = '2.2.2';
+    const DIRECTUS_VERSION = '2.3.0';
 
     /**
      * NOT USED

--- a/src/core/Directus/Filesystem/Thumbnail.php
+++ b/src/core/Directus/Filesystem/Thumbnail.php
@@ -116,12 +116,13 @@ class Thumbnail
         if (!extension_loaded('imagick')) {
             return false;
         }
-
         $image = new \Imagick();
         $image->readImageBlob($content);
         $image->setIteratorIndex(0);
         $image->setImageFormat($format);
-
+        $image->setImageBackgroundColor('#ffffff');
+        $image->setImageAlphaChannel(\Imagick::ALPHACHANNEL_REMOVE);
+        $image = $image->mergeImageLayers(\Imagick::LAYERMETHOD_FLATTEN);
         return $image->getImageBlob();
     }
 


### PR DESCRIPTION
Solving #1081 

Reusing the code in Filesystem/ that existed (in previous version?)

Only works when the imagick module is installed.
When imagick is not installed the current behaviour is preserved.