### PR TITLE
Added file support for 7.0 (Explained)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@directus/api",
   "private": true,
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Directus API",
   "main": "index.js",
   "repository": "directus/api",

--- a/src/core/Directus/Application/Application.php
+++ b/src/core/Directus/Application/Application.php
@@ -13,7 +13,7 @@ class Application extends App
      *
      * @var string
      */
-    const DIRECTUS_VERSION = '2.2.2';
+    const DIRECTUS_VERSION = '2.3.0';
 
     /**
      * NOT USED

--- a/src/core/Directus/Config/Schema/Types.php
+++ b/src/core/Directus/Config/Schema/Types.php
@@ -7,8 +7,8 @@ namespace Directus\Config\Schema;
  */
 interface Types
 {
-    public const INTEGER = 'number';
-    public const FLOAT = 'float';
-    public const STRING = 'string';
-    public const BOOLEAN = 'boolean';
+    const INTEGER = 'number';
+    const FLOAT = 'float';
+    const STRING = 'string';
+    const BOOLEAN = 'boolean';
 }


### PR DESCRIPTION
Having `public` in front of `const` completely breaks the application for `PHP 7.0` usage, which broke everything when I pulled origin.

Though I understand `PHP 7.0` isn't officially supported, and that `PHP 7.1+` is, there is no reason to use public alongside const as the default visibility of class constants are public. We might as well provide support where possible if it doesn't hurt.

Also explained here:
https://stackoverflow.com/a/51568547