### PR TITLE
Add thumbnails for PDF. Fix #1081

### DIFF
--- a/src/helpers/file.php
+++ b/src/helpers/file.php
@@ -6,6 +6,7 @@ use Directus\Application\Application;
 use Directus\Filesystem\Thumbnail;
 use function Directus\get_directus_setting;
 use Directus\Validator\Exception\InvalidRequestException;
+use Directus\Util\MimeTypeUtils;
 
 if (!function_exists('is_uploaded_file_okay')) {
     /**
@@ -190,6 +191,7 @@ if (!function_exists('get_thumbnails')) {
      */
     function get_thumbnails(array $row)
     {
+
         $filename = $row['filename'];
         $type = array_get($row, 'type');
         $thumbnailFilenameParts = explode('.', $filename);
@@ -198,7 +200,8 @@ if (!function_exists('get_thumbnails')) {
             explode(',', get_directus_setting('thumbnail_dimensions'))
         );
 
-        if (!$type || (strpos($type, 'image/') !== 0 && strpos($type, 'embed/') !== 0)) {
+        $fileExtension = MimeTypeUtils::getFromMimeType($type);
+        if (!in_array($fileExtension, Thumbnail::getFormatsSupported())  &&  strpos($type, 'embed/') !== 0) {
             return null;
         }
 
@@ -216,6 +219,7 @@ if (!function_exists('get_thumbnails')) {
             }
 
             $size = explode('x', $dimension);
+
             if (count($size) == 2) {
                 $thumbnailUrl = get_thumbnail_url($filename, $size[0], $size[1]);
                 $thumbnailRelativeUrl = get_thumbnail_path($filename, $size[0], $size[1]);
@@ -295,7 +299,8 @@ if (!function_exists('get_proxy_path')) {
         // env/width/height/mode/quality/name
         return sprintf(
             '/downloads/%s/%s',
-            $projectName, $path
+            $projectName,
+            $path
         );
     }
 }
@@ -363,17 +368,16 @@ if (!function_exists('validate_file')) {
      *
      * @return bool
      */
-    function validate_file($value,$constraint,$options = null)
+    function validate_file($value, $constraint, $options = null)
     {
-       switch ($constraint) {
+        switch ($constraint) {
             case 'mimeTypes':
-                validate_file_mime_type($value,$options);
-            break;
+                validate_file_mime_type($value, $options);
+                break;
             case 'maxSize':
-                validate_file_size($value,$options);
-            break;
-
-       }
+                validate_file_size($value, $options);
+                break;
+        }
     }
 }
 
@@ -385,14 +389,14 @@ if (!function_exists('validate_file_mime_type')) {
      *
      * @return bool
      */
-    function validate_file_mime_type($value,$options)
+    function validate_file_mime_type($value, $options)
     {
         $mimeTypes = $options;
         $mime = $value;
-        
-        if($options == null) {
-            $options=get_directus_setting('file_mimetype_whitelist');
-            $mimeTypes = explode(",",$options);
+
+        if ($options == null) {
+            $options = get_directus_setting('file_mimetype_whitelist');
+            $mimeTypes = explode(",", $options);
         }
         foreach ($mimeTypes as $mimeType) {
             if ($mimeType === $mime) {
@@ -404,7 +408,7 @@ if (!function_exists('validate_file_mime_type')) {
                 }
             }
         }
-        $message='The mime type of the file is invalid.Allowed mime types are '.$options.'.';
+        $message = 'The mime type of the file is invalid.Allowed mime types are ' . $options . '.';
         throw new InvalidRequestException($message);
     }
 }
@@ -416,13 +420,13 @@ if (!function_exists('validate_file_size')) {
      *
      * @return bool
      */
-    function validate_file_size($value,$options)
+    function validate_file_size($value, $options)
     {
-        $maxSize=$options;
-        if($options == null) {
-            $maxSize=get_directus_setting('file_max_size');
+        $maxSize = $options;
+        if ($options == null) {
+            $maxSize = get_directus_setting('file_max_size');
         }
-        $size=$maxSize;
+        $size = $maxSize;
         $factors = [
             'KB' => 1000,
             'MB' => 1000000,
@@ -431,21 +435,20 @@ if (!function_exists('validate_file_size')) {
         ];
         if (ctype_digit((string) $maxSize)) {
             $maxSize = (int) $maxSize;
-        } elseif (preg_match('/^(\d++)('.implode('|', array_keys($factors)).')$/', $maxSize, $matches)) {
+        } elseif (preg_match('/^(\d++)(' . implode('|', array_keys($factors)) . ')$/', $maxSize, $matches)) {
             $maxSize = $matches[1] * $factors[$unit = $matches[2]];
         } else {
             throw new InvalidRequestException(sprintf('"%s" is not a valid maximum size.', $size));
         }
 
         if (0 === $value) {
-            $message='An empty file is not allowed.';
+            $message = 'An empty file is not allowed.';
             throw new InvalidRequestException($message);
         }
 
-        if($value > $maxSize){
-            $message='The file is too large. Allowed maximum size is '.$size.'.';
+        if ($value > $maxSize) {
+            $message = 'The file is too large. Allowed maximum size is ' . $size . '.';
             throw new InvalidRequestException($message);
         }
     }
 }
-


### PR DESCRIPTION
Thumbnail supported file extensions.
`jpg`, `jpeg`, `gif`, `png`, `svg`, `pdf`, `psd`, `tif`, `tiff` 

Thumbnail supported type.
`embed`