### PR TITLE
Parent + Nested validation changes

### DIFF
--- a/src/core/Directus/Services/ItemsService.php
+++ b/src/core/Directus/Services/ItemsService.php
@@ -12,6 +12,7 @@ use Directus\Util\StringUtils;
 use Directus\Validator\Exception\InvalidRequestException;
 use Zend\Db\TableGateway\TableGateway;
 use Directus\Database\SchemaService;
+use Directus\Database\Schema\DataTypes;
 
 class ItemsService extends AbstractService
 {
@@ -182,7 +183,7 @@ class ItemsService extends AbstractService
         foreach($tableColumns as $key => $column){
             if(!empty($recordData)  && !$column->hasPrimaryKey()){
                 $columnName = $column->getName(); 
-                $collectionFields[$columnName] = isset($collectionFields[$column->getName()]) ? $collectionFields[$column->getName()]: $recordData[$columnName];
+                $collectionFields[$columnName] = array_key_exists($column->getName(), $collectionFields) ? $collectionFields[$column->getName()]: (DataTypes::isJson($column->getType()) ? (array) $recordData[$columnName] : $recordData[$columnName]);
             }
         }
         
@@ -211,14 +212,14 @@ class ItemsService extends AbstractService
                             $columnName = $column->getName();
                             if($search !== false){
                                 $dbObj = isset($storedData[$search][$aliasField]) ? $storedData[$search][$aliasField] : [];
-                                $validatePayload[$columnName] = isset($validatePayload[$columnName]) ? $validatePayload[$columnName]: (isset($dbObj[$columnName]) ? $dbObj[$columnName] : null);
+                                $validatePayload[$columnName] = array_key_exists($columnName, $validatePayload) ? $validatePayload[$columnName]: (isset($dbObj[$columnName]) ? ((DataTypes::isJson($column->getType()) ? (array) $dbObj[$columnName] : $dbObj[$columnName])) : null);
                             }else{
                                 $relationalCollectionData = $this->findByIds(
                                     $relationalCollectionName,
                                     $validatePayload[$relationalCollectionPrimaryKey],
                                     $params
                                 );
-                                $validatePayload[$columnName] = isset($validatePayload[$columnName]) ? $validatePayload[$columnName]: (isset($relationalCollectionData['data'][$columnName]) ? $relationalCollectionData['data'][$columnName] : null);
+                                $validatePayload[$columnName] = array_key_exists($columnName, $validatePayload) ? $validatePayload[$columnName]: (isset($relationalCollectionData['data'][$columnName]) ? ((DataTypes::isJson($column->getType()) ? (array) $relationalCollectionData['data'][$columnName] : $relationalCollectionData['data'][$columnName])) : null);
                             }
                         }
                     }
@@ -255,14 +256,14 @@ class ItemsService extends AbstractService
                             $search = array_search($individual[$relationalCollectionPrimaryKey], array_column($recordData[$colName], $relationalCollectionPrimaryKey));
                             $columnName = $column->getName();
                             if($search !== false){
-                                $individual[$columnName] = isset($individual[$columnName]) ? $individual[$columnName]: (isset($recordData[$colName][$search][$columnName]) ? $recordData[$colName][$search][$columnName] : null);
+                                $individual[$columnName] = array_key_exists($columnName, $individual) ? $individual[$columnName]: (isset($recordData[$colName][$search][$columnName]) ? ((DataTypes::isJson($column->getType()) ? (array) $recordData[$colName][$search][$columnName] : $recordData[$colName][$search][$columnName])) : null);
                             }else{
                                 $relationalCollectionData = $this->findByIds(
                                     $relationalCollectionName,
                                     $individual[$relationalCollectionPrimaryKey],
                                     $params
                                 );
-                                $individual[$columnName] = isset($individual[$columnName]) ? $individual[$columnName]: (isset($relationalCollectionData['data'][$columnName]) ? $relationalCollectionData['data'][$columnName] : null);
+                                $individual[$columnName] = array_key_exists($columnName, $individual) ? $individual[$columnName]: (isset($relationalCollectionData['data'][$columnName]) ? ((DataTypes::isJson($column->getType()) ? (array) $relationalCollectionData['data'][$columnName] : $relationalCollectionData['data'][$columnName])) : null);
                             }
                         }
                     }


### PR DESCRIPTION
**Issue 1(Drag column in listing page of APP):** **findByIds** is returning value as **Object** for JSON datatype fields, so that it is creating an issue in parent validation and nested payload validation.
**Solution:** Converted Object into the array for JSON fields.

**Issue 2:** Let's say a collection has JSON field and it is required, in update item remove value from it, for blank JSON field NULL value is passing, so that `isset` is not working for NULL value and creating issue in validation.
**Solution:** Used `array_key_exists` in place of `isset`