### PR TITLE
Resolve the error of validation of primary key

### DIFF
--- a/src/core/Directus/Services/ItemsService.php
+++ b/src/core/Directus/Services/ItemsService.php
@@ -194,7 +194,7 @@ class ItemsService extends AbstractService
         $collectionFields = $payload;
         
         foreach($tableColumns as $key => $column){
-            if(!empty($recordData)  && !$column->hasPrimaryKey()){
+            if(!empty($recordData)){
                 $columnName = $column->getName(); 
                 $collectionFields[$columnName] = array_key_exists($column->getName(), $collectionFields) ? $collectionFields[$column->getName()]: (DataTypes::isJson($column->getType()) ? (array) $recordData[$columnName] : $recordData[$columnName]);
             }


### PR DESCRIPTION
When a collection has a string primary key and an entry in that collection is updated. The app doesn't send the primary key with the patch request and since it's required it throws a validation error.

`id: This value should not be blank.`

This PR will resolve this issue.