### PR TITLE
Add option to prevent upsizing contained thumbnails

### DIFF
--- a/src/core/Directus/Filesystem/Thumbnailer.php
+++ b/src/core/Directus/Filesystem/Thumbnailer.php
@@ -179,9 +179,12 @@ class Thumbnailer {
             // crop image
             $img->resize($this->width, $this->height, function ($constraint) {
                 $constraint->aspectRatio();
+                if (ArrayUtils::get($options, 'preventUpsize')) {
+                    $constraint->upsize();
+                }
             });
 
-            if( ArrayUtils::get($options, 'resizeCanvas')) {
+            if (ArrayUtils::get($options, 'resizeCanvas')) {
                 $img->resizeCanvas($this->width, $this->height, ArrayUtils::get($options, 'position', 'center'), ArrayUtils::get($options, 'resizeRelative', false), ArrayUtils::get($options, 'canvasBackground', [255, 255, 255, 0]));
             }
 


### PR DESCRIPTION
I am using the thumbnailer to load all images to provide sanitization of user uploaded content -- I would rather pass the image through Intervention than serve the original upload to visitors, in case it was malicious.

Currently the thumbnailer forces the requested size, and will scale up images, but for this use case I would rather not scale up images. The resize method we use has a `upsize` constraint which prevents scaling the image [1].

I've exposed this as an option so it's backwards compatible.

I had a look for tests but couldn't find any. Do we want tests on the thumbnailer endpoints, or unit tests?

Thanks!  😀

[1] http://image.intervention.io/api/resize