### PR TITLE
Don't use special characters in creation of project auth tokens

### DIFF
--- a/src/core/Directus/Util/Installation/InstallerUtils.php
+++ b/src/core/Directus/Util/Installation/InstallerUtils.php
@@ -880,7 +880,7 @@ class InstallerUtils
     private static function createConfigData(array $data)
     {
         $corsEnabled = ArrayUtils::get($data, 'cors_enabled', true);
-        $authSecret = ArrayUtils::get($data, 'auth_secret', StringUtils::randomString(32));
+        $authSecret = ArrayUtils::get($data, 'auth_secret', StringUtils::randomString(32, false));
         $authPublic = ArrayUtils::get($data, 'auth_public', generate_uuid4());
 
         return ArrayUtils::defaults([
@@ -891,7 +891,7 @@ class InstallerUtils
             'db_password' => null,
             'db_socket' => '',
             'mail_from' => 'admin@example.com',
-            'feedback_token' => sha1(gmdate('U') . StringUtils::randomString(32)),
+            'feedback_token' => sha1(gmdate('U') . StringUtils::randomString(32, false)),
             'feedback_login' => true,
             'timezone' => get_default_timezone(),
             'cache' => [

--- a/src/core/Directus/Util/StringUtils.php
+++ b/src/core/Directus/Util/StringUtils.php
@@ -123,10 +123,14 @@ class StringUtils
      *
      * @return string
      */
-    public static function randomString($length = 16)
+    public static function randomString($length = 16, $special_chars = true)
     {
         // TODO: Add options to allow symbols or user provided characters to extend the list
-        $pool = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+}{';'?>.<,";
+        $pool = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        if ($special_chars) {
+            $pool .= "!@#$%^&*()_+}{;?>.<,";
+        }
 
         return substr(str_shuffle(str_repeat($pool, $length)), 0, $length);
     }
@@ -234,7 +238,7 @@ class StringUtils
         }
 
         /**
-         * If any variable of the given string have null value as a replacement then the 
+         * If any variable of the given string have null value as a replacement then the
          * result will be 'null'(string). So we need to replace it with blank string.
          */
         $string = str_replace("'null'", "''", $string);


### PR DESCRIPTION
The `StringUtils::randomString` method had a pool of characters including the `'` character. This string would be put inside the config file directly which could potentially conflict in the config file of the newly created project:

```php
[
  'auth_secret' => 'random-token-includes-a-'-and-messes-up-the-string'
]
```

This PR fixes that by adding a secondary parameter to the `randomString` util called `special_chars` that will enable / disable the inclusion of special characters in this string. It's turned on by default so it doesn't change any of the usage elsewhere in the system, while allowing the project creation service to not include special characters. 