### PR TITLE
Issue Fix #1180

### DIFF
--- a/src/core/Directus/Services/AbstractService.php
+++ b/src/core/Directus/Services/AbstractService.php
@@ -196,7 +196,7 @@ abstract class AbstractService
      * 
      * @return array
      */
-    protected function createConstraintFor($collectionName, array $fields = [], $skipRelatedCollectionField = '')
+    protected function createConstraintFor($collectionName, array $fields = [], $skipRelatedCollectionField = '', array $params = [] )
     {
         /** @var SchemaManager $schemaManager */
         $schemaManager = $this->container->get('schema_manager');
@@ -217,6 +217,10 @@ abstract class AbstractService
             $columnConstraints = [];
 
             if ($field->hasAutoIncrement()) {
+                continue;
+            }
+
+            if ($field->getName() == "password" && isset($params['select_existing_or_update'])) {
                 continue;
             }
 
@@ -376,13 +380,13 @@ abstract class AbstractService
         if (is_array($fields)) {
             $columnsToValidate = $fields;
         }
-
+      
         $this->validatePayloadFields($collectionName, $payload);
         // TODO: Ideally this should be part of the validator constraints
         // we need to accept options for the constraint builder
         $this->validatePayloadWithFieldsValidation($collectionName, $payload);
        
-        $this->validate($payload, $this->createConstraintFor($collectionName, $columnsToValidate, $skipRelatedCollectionField));
+        $this->validate($payload, $this->createConstraintFor($collectionName, $columnsToValidate, $skipRelatedCollectionField,$params));
     }
 
     /**

--- a/src/core/Directus/Services/ItemsService.php
+++ b/src/core/Directus/Services/ItemsService.php
@@ -195,10 +195,11 @@ class ItemsService extends AbstractService
                 if(!isset($individual['$delete'])){
                     $aliasField = $aliasColumnDetails->getRelationship()->getJunctionOtherRelatedField();
                     $validatePayload = $individual[$aliasField];
-
-
+                    if(!isset($params['fields'])){
+                        $params['fields'] = "*.*";
+                    }
                     foreach($relationalCollectionColumns as $column){
-                        if(!$column->isAlias() && !$column->hasPrimaryKey() && !empty($validatePayload[$relationalCollectionPrimaryKey])){
+                        if(!$column->hasPrimaryKey() && !empty($validatePayload[$relationalCollectionPrimaryKey])){
                             $columnName = $column->getName();
                             $relationalCollectionData = $this->findByIds(
                                 $relationalCollectionName,
@@ -206,6 +207,7 @@ class ItemsService extends AbstractService
                                 $params
                             );
                             $validatePayload[$columnName] = array_key_exists($columnName, $validatePayload) ? $validatePayload[$columnName]: (isset($relationalCollectionData['data'][$columnName]) ? ((DataTypes::isJson($column->getType()) ? (array) $relationalCollectionData['data'][$columnName] : $relationalCollectionData['data'][$columnName])) : null);
+                            $params['select_existing_or_update'] = true;
                         }
                     }
                     $this->validatePayload($relationalCollectionName, null, $validatePayload,$params);


### PR DESCRIPTION
As per the current code, from the `directus_users` table the `password` will be set as `null` when the user tries to fetch the data from it. This PR will omit `password` validation if the user tries to update or select an existing user.