### PR TITLE
Update collections() method in types.php

### DIFF
--- a/src/core/Directus/GraphQL/Types.php
+++ b/src/core/Directus/GraphQL/Types.php
@@ -136,12 +136,13 @@ class Types
 
     public static function collections($type)
     {
-        if (!array_key_exists($type, self::$collections)) {
+        $key  = is_subclass_of($type, 'GraphQL\Type\Definition\ObjectType') ? $type->name : $type;
+        if (!array_key_exists($key, self::$collections)) {
             $collectionType =  new CollectionType($type);
-            self::$collections[$type] = $collectionType;
+            self::$collections[$key] = $collectionType;
             return $collectionType;
         } else {
-            return self::$collections[$type];
+            return self::$collections[$key];
         }
     }
 


### PR DESCRIPTION
There are cases when $type is not a string but an object that inherits from ObjectType.
In that situation array_key_exists failing because it should get only integers or strings 
as a first parameter. So in order to avoid that the 'name' property of the object is used 
as a key.