### PR TITLE
Fix #1203 [Remove readonly condition for duration field of directus_files table]

### DIFF
--- a/migrations/upgrades/schemas/20190819070856_update_directus_fields_field.php
+++ b/migrations/upgrades/schemas/20190819070856_update_directus_fields_field.php
@@ -1,0 +1,22 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class UpdateDirectusFieldsField extends AbstractMigration
+{
+    public function up()
+    {
+        $this->execute(\Directus\phinx_update(
+            $this->getAdapter(),
+            'directus_fields',
+            [
+              'readonly' => 0,
+              'note' => 'Duration must be in seconds'
+            ],
+            ['collection' => 'directus_files', 'field' => 'duration']
+        ));
+
+
+    }
+}

--- a/src/core/Directus/Services/FilesServices.php
+++ b/src/core/Directus/Services/FilesServices.php
@@ -88,13 +88,16 @@ class FilesServices extends AbstractService
         $this->validatePayload($this->collection, array_keys($data), $data, $params);
 
         $files = $this->container->get('files');
-        $result=$files->getFileSizeType($data['data']);
 
-        if(get_directus_setting('file_mimetype_whitelist') != null){
-            validate_file($result['mimeType'],'mimeTypes');
-        }
-        if(get_directus_setting('file_max_size') != null){
-            validate_file($result['size'],'maxSize');
+        if(isset($data['data'])){
+            $result=$files->getFileSizeType($data['data']);
+    
+            if(get_directus_setting('file_mimetype_whitelist') != null){
+                validate_file($result['mimeType'],'mimeTypes');
+            }
+            if(get_directus_setting('file_max_size') != null){
+                validate_file($result['size'],'maxSize');
+            }
         }
         
         $tableGateway = $this->createTableGateway($this->collection);


### PR DESCRIPTION
This PR will resolve the warning of undefined index `data` too when uploading file in the `development` env.