### PR TITLE
Improve YouTube Embed Provider

### DIFF
--- a/src/core/Directus/Embed/Provider/YoutubeProvider.php
+++ b/src/core/Directus/Embed/Provider/YoutubeProvider.php
@@ -16,7 +16,7 @@ class YoutubeProvider extends AbstractProvider
      */
     public function validateURL($url)
     {
-        return strpos($url, 'youtube.com') !== false;
+        return (bool) preg_match("@^(https?\:\/\/)?(www\.)|(m\.)?(youtube\.com|youtu\.?be)\/.+$@", $url);
     }
 
     /**
@@ -33,9 +33,13 @@ class YoutubeProvider extends AbstractProvider
     protected function parseURL($url)
     {
         // Get ID from URL
-        parse_str(parse_url($url, PHP_URL_QUERY), $urlParameters);
-        $videoID = isset($urlParameters['v']) ? $urlParameters['v'] : false;
-
+        if(strpos($url, 'youtu.be')) {
+            $urlElements = parse_url($url);
+            $videoID = isset($urlElements['path']) && strlen($urlElements['path']) > 1 ? ltrim($urlElements['path'], '/') : false;
+        } else {
+            parse_str(parse_url($url, PHP_URL_QUERY), $urlParameters);
+            $videoID = isset($urlParameters['v']) ? $urlParameters['v'] : false;
+        }
         // Can't find the video ID
         if (!$videoID) {
             throw new \Exception('YouTube ID not detected');


### PR DESCRIPTION
Hello everyone,

I noticed the YouTube Embed Provider did not provide a way to parse youtu.be URLs.

I took upon myself brushing up my PHP, and came up with this solution. By replacing the `strpos` by a `preg_match` (with a regex found on StackOverflow), youtu.be is now a valid URL for a YouTube Embed.

I also added some code to support this URL scheme in the `parseURL` function; if "youtu.be" is in the url, it parses the url, gets the path and trims the `/` from it. If it's not the case, it goes to the original function.

I hope this could be useful! 