### PR TITLE
added file meta data for audio/video

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "ext-gd": "*",
-    "webonyx/graphql-php": "^0.13.0"
+    "webonyx/graphql-php": "^0.13.0",
+    "char0n/ffmpeg-php": "^3.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7.25",

--- a/src/core/Directus/Filesystem/Files.php
+++ b/src/core/Directus/Filesystem/Files.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace Directus\Filesystem;
-require_once '/var/www/html/vendor/autoload.php';
 
 use Char0n\FFMpegPHP\Movie;
 use Directus\Application\Application;


### PR DESCRIPTION
As per description from @benhaynes in #1204 this feature will dynamically set width,height and duration for video and duration for audio files.
It uses the Char0n\FFMpegPHP php library, so need to add composer reference to add the required library when installing.
Due to our requirements for the files to be stored on AWS s3 with a signed url, it saves the file temporarily locally to determine the metadata.

Tested with 194Mb mp4 video file, and 30mb audio file. 