### PR TITLE
Fix #1209 [M2M relation with directus_collections cant be saved]

### DIFF
--- a/src/core/Directus/Services/RelationsService.php
+++ b/src/core/Directus/Services/RelationsService.php
@@ -4,6 +4,7 @@ namespace Directus\Services;
 
 use Directus\Application\Container;
 use Directus\Database\Schema\SchemaManager;
+use Directus\Database\Exception\ForbiddenSystemTableDirectAccessException;
 
 class RelationsService extends AbstractService
 {
@@ -25,8 +26,23 @@ class RelationsService extends AbstractService
         $this->itemsService = new ItemsService($this->container);
     }
 
+    public function throwErrorIfRestrictedTable($name)
+    {
+        $restrictedTables = [
+            SchemaManager::COLLECTION_ACTIVITY,
+            SchemaManager::COLLECTION_COLLECTIONS,
+            SchemaManager::COLLECTION_FIELDS,
+            SchemaManager::COLLECTION_RELATIONS
+        ];
+        if (in_array($name, $restrictedTables)) {
+            throw new ForbiddenSystemTableDirectAccessException($this->collection);
+        }
+    }
+
+
     public function create(array $data, array $params = [])
     {
+        $this->throwErrorIfRestrictedTable($data['collection_one']);
         return $this->itemsService->createItem($this->collection, $data, $params);
     }
 

--- a/src/core/Directus/Services/RelationsService.php
+++ b/src/core/Directus/Services/RelationsService.php
@@ -18,6 +18,16 @@ class RelationsService extends AbstractService
      */
     protected $itemsService;
 
+    /**
+     * @var string
+     */
+    protected $restrictedTables = [
+        SchemaManager::COLLECTION_ACTIVITY,
+        SchemaManager::COLLECTION_COLLECTIONS,
+        SchemaManager::COLLECTION_FIELDS,
+        SchemaManager::COLLECTION_RELATIONS
+    ];
+
     public function __construct(Container $container)
     {
         parent::__construct($container);
@@ -28,13 +38,7 @@ class RelationsService extends AbstractService
 
     public function throwErrorIfRestrictedTable($name)
     {
-        $restrictedTables = [
-            SchemaManager::COLLECTION_ACTIVITY,
-            SchemaManager::COLLECTION_COLLECTIONS,
-            SchemaManager::COLLECTION_FIELDS,
-            SchemaManager::COLLECTION_RELATIONS
-        ];
-        if (in_array($name, $restrictedTables)) {
+        if (in_array($name, $this->restrictedTables)) {
             throw new ForbiddenSystemTableDirectAccessException($this->collection);
         }
     }
@@ -58,6 +62,7 @@ class RelationsService extends AbstractService
 
     public function update($id, array $data, array $params = [])
     {
+        $this->throwErrorIfRestrictedTable($data['collection_one']);
         return $this->itemsService->update($this->collection, $id, $data, $params);
     }
 

--- a/src/core/Directus/Services/RelationsService.php
+++ b/src/core/Directus/Services/RelationsService.php
@@ -19,9 +19,9 @@ class RelationsService extends AbstractService
     protected $itemsService;
 
     /**
-     * @var string
+     * @var array
      */
-    protected $restrictedTables = [
+    public $restrictedTables = [
         SchemaManager::COLLECTION_ACTIVITY,
         SchemaManager::COLLECTION_COLLECTIONS,
         SchemaManager::COLLECTION_FIELDS,

--- a/src/core/Directus/Services/RelationsService.php
+++ b/src/core/Directus/Services/RelationsService.php
@@ -39,7 +39,7 @@ class RelationsService extends AbstractService
     public function throwErrorIfRestrictedTable($name)
     {
         if (in_array($name, $this->restrictedTables)) {
-            throw new ForbiddenSystemTableDirectAccessException($this->collection);
+            throw new ForbiddenSystemTableDirectAccessException($name);
         }
     }
 


### PR DESCRIPTION
Restrict `directus_collections`, `directus_fields`, `directus_activities `and `directus_relations` tables from adding as a relation