### PR TITLE
Project name fix

### DIFF
--- a/src/core/Directus/Authentication/Provider.php
+++ b/src/core/Directus/Authentication/Provider.php
@@ -171,7 +171,7 @@ class Provider
 
         // Verify that the user has an id (exists), it returns empty user object otherwise
         if (!password_verify($password, $user->get('password'))) {
-            
+
             $this->recordActivityAndCheckLoginAttempt($user);
             throw new InvalidUserCredentialsException();
         }
@@ -207,7 +207,7 @@ class Provider
         $activityTableGateway->recordAction($userId, SchemaManager::COLLECTION_USERS, DirectusActivityTableGateway::ACTION_INVALID_CREDENTIALS);
 
         $loginAttemptsAllowed = get_directus_setting('login_attempts_allowed');
-        
+
         if(!empty($loginAttemptsAllowed)){
 
             // We added 'Invalid credentials' entry before this condition so need to increase this counter with 1
@@ -217,11 +217,11 @@ class Provider
             if(!empty($invalidLoginAttempts)){
                 $lastInvalidCredentialsEntry = current($invalidLoginAttempts);
                 $firstInvalidCredentialsEntry = end($invalidLoginAttempts);
-              
+
                 $lastLoginAttempt = $activityTableGateway->getLastLoginOrStatusUpdateAttempt($userId);
-              
+
                 if(!empty($lastLoginAttempt) && !in_array($lastLoginAttempt['id'], range($firstInvalidCredentialsEntry['id'], $lastInvalidCredentialsEntry['id'])) &&  count($invalidLoginAttempts) > $loginAttemptsAllowed){
-                    
+
                     $tableGateway = TableGatewayFactory::create(SchemaManager::COLLECTION_USERS, ['acl' => false]);
                     $update = [
                         'status' => DirectusUsersTableGateway::STATUS_SUSPENDED
@@ -605,11 +605,11 @@ class Provider
     /**
      * Authentication secret key
      *
-     * @param string|null $project
+     * @param string $project
      *
      * @return string
      */
-    public function getSecretKey($project = null)
+    public function getSecretKey($project = '_')
     {
         if ($project) {
             $config = get_project_config($project);

--- a/src/core/Directus/Util/DateTimeUtils.php
+++ b/src/core/Directus/Util/DateTimeUtils.php
@@ -83,7 +83,7 @@ class DateTimeUtils extends \DateTime
         if ($timezone) {
             $timezone = $this->createTimeZone($timezone);
         }
-        
+
         parent::__construct($time, $timezone);
         if ($time === null) {
             $this->setTimestamp(time());
@@ -109,7 +109,7 @@ class DateTimeUtils extends \DateTime
 
     public static function nowInTimezone()
     {
-        $config = get_project_config();;
+        $config = get_project_config();
         return static::now($config->get('app.timezone'));
     }
 
@@ -182,11 +182,11 @@ class DateTimeUtils extends \DateTime
         if ($timezone instanceof DateTimeZone) {
             return $timezone;
         }
-        
+
         if ($timezone === null) {
             return new DateTimeZone(date_default_timezone_get());
         }
-        
+
         try {
             $timezone = new DateTimeZone($timezone);
         } catch (\Exception $e) {

--- a/src/helpers/app.php
+++ b/src/helpers/app.php
@@ -67,7 +67,7 @@ if (!function_exists('get_project_config')) {
      *
      * @throws Exception
      */
-    function get_project_config($name = null, $basePath = null)
+    function get_project_config($name = '_', $basePath = null)
     {
         static $configs = [];
 


### PR DESCRIPTION
This fixes issue #1271. 

It was due to a call that doesn't set the proper project name. This PR makes it default to use "_" the project name value.

Please check if this change doesn't impact any other environments before merging, as I just tested locally in docker.
