### PR TITLE
fixed bug with incorrect height

### DIFF
--- a/src/core/Directus/Filesystem/Files.php
+++ b/src/core/Directus/Filesystem/Files.php
@@ -324,7 +324,7 @@ class Files
             'charset' => $fileData['charset'],
             'filesize' => $fileData['size'],
             'width' => isset($width) ? $width : $fileData['width'],
-            'height' => isset($height) ? $width : $fileData['height'],
+            'height' => isset($height) ? $height : $fileData['height'],
             'storage' => $fileData['storage'],
             'checksum' => $checksum,
             'duration' => isset($duration) ? $duration : 0


### PR DESCRIPTION
After running tests locally uploading mp4 files, It was setting the height property to be the width. There was a typo in original PR. This fixes that and now correctly sets the width and height.