### PR TITLE
Extend config schema to support PDO options.

### DIFF
--- a/config/api_sample.php
+++ b/config/api_sample.php
@@ -24,9 +24,11 @@ return [
         // When using unix socket to connect to the database the host attribute should be removed
         // 'socket' => '/var/lib/mysql/mysql.sock',
         'socket' => '',
-        'driver_options' => [
-            PDO::MYSQL_ATTR_SSL_CAPATH => '/etc/ssl/certs',
-        ]
+        // Connect over TLS by using the appropriate PDO_MySQL constants:
+        // https://www.php.net/manual/en/ref.pdo-mysql.php#pdo-mysql.constants
+        //'driver_options' => [
+        //    PDO::MYSQL_ATTR_SSL_CAPATH => '/etc/ssl/certs',
+        //]
     ],
 
     'cache' => [

--- a/config/api_sample.php
+++ b/config/api_sample.php
@@ -24,6 +24,9 @@ return [
         // When using unix socket to connect to the database the host attribute should be removed
         // 'socket' => '/var/lib/mysql/mysql.sock',
         'socket' => '',
+        'driver_options' => [
+            PDO::MYSQL_ATTR_SSL_CAPATH => '/etc/ssl/certs',
+        ]
     ],
 
     'cache' => [

--- a/src/core/Directus/Config/Schema/Schema.php
+++ b/src/core/Directus/Config/Schema/Schema.php
@@ -38,7 +38,7 @@ class Schema {
                 new Value('engine', Types::STRING, 'InnoDB'),
                 new Value('charset', Types::STRING, 'utf8mb4'),
                 new Value('socket', Types::STRING, ''),
-                new Value('driver_options', Types::ARRAY, []),
+                new Value('driver_options?', Types::ARRAY, []),
             ]),
             new Group('cache', [
                 new Value('enabled', Types::BOOLEAN, false),

--- a/src/core/Directus/Config/Schema/Schema.php
+++ b/src/core/Directus/Config/Schema/Schema.php
@@ -38,6 +38,7 @@ class Schema {
                 new Value('engine', Types::STRING, 'InnoDB'),
                 new Value('charset', Types::STRING, 'utf8mb4'),
                 new Value('socket', Types::STRING, ''),
+                new Value('driver_options', Types::ARRAY, []),
             ]),
             new Group('cache', [
                 new Value('enabled', Types::BOOLEAN, false),


### PR DESCRIPTION
Extending the schema with this option allows me to connect to MySQL over a TLS connection.