### PR TITLE
Add Aliyun OSS settings to config schema

### DIFF
--- a/src/core/Directus/Config/Schema/Schema.php
+++ b/src/core/Directus/Config/Schema/Schema.php
@@ -54,6 +54,7 @@ class Schema {
                 new Value('root', Types::STRING, 'public/uploads/_/originals'),
                 new Value('root_url', Types::STRING, '/uploads/_/originals'),
                 new Value('thumb_root', Types::STRING, 'public/uploads/_/thumbnails'),
+                new Value('proxy_downloads?', Types::BOOLEAN, false),
 
                 // S3
                 new Value('key?', Types::STRING, 's3-key'),
@@ -66,6 +67,12 @@ class Schema {
                     new Value('ACL', Types::STRING, 'public-read'),
                     new Value('Cache-Control', Types::STRING, 'max-age=604800')
                 ]),
+
+                // OSS
+                new Value('OSS_ACCESS_ID?', Types::STRING, 'oss-access-id'),
+                new Value('OSS_ACCESS_KEY?', Types::STRING, 'oss-access-secret'),
+                new Value('OSS_BUCKET?', Types::STRING, 'oss-bucket'),
+                new Value('OSS_ENDPOINT?', Types::STRING, 'oss-endpoint'),
 
                 // TODO: Missing keys?
             ]),


### PR DESCRIPTION
Aliyun OSS settings required by [FilesystemFactory](https://github.com/directus/api/blob/8a1187ff0b3559ab7281c4990d5329d47d8835dd/src/core/Directus/Filesystem/FilesystemFactory.php#L80) is missing from the schema.

Also added `proxy_downloads` to the schema (implemented in #860).