### PR TITLE
Fix Undefined Variable - when Running bin/directus install:install

### DIFF
--- a/src/core/Directus/Console/Common/Setting.php
+++ b/src/core/Directus/Console/Common/Setting.php
@@ -21,7 +21,7 @@ class Setting
 
         $this->directus_path = $base_path;
 
-        $app = InstallerUtils::createApp($base_path, $config);
+        $app = InstallerUtils::createApp($base_path, $projectName);
         $this->db = $app->getContainer()->get('database');
 
         $this->settingsTableGateway = new TableGateway('directus_settings', $this->db);


### PR DESCRIPTION
```
PHP Notice:  Undefined variable: config in webrootsrc/core/Directus/Console/Common/Setting.php on line 24
PHP Stack trace:
PHP   1. {main}() webrootbin/directus:0
PHP   2. Directus\Console\Cli->run() webrootbin/directus:10
PHP   3. Directus\Console\Cli->cmd() webrootsrc/core/Directus/Console/Cli.php:64
PHP   4. Directus\Console\Modules\InstallModule->runCommand() webrootsrc/core/Directus/Console/Cli.php:88
PHP   5. Directus\Console\Modules\InstallModule->cmdInstall() webrootsrc/core/Directus/Console/Modules/ModuleBase.php:61
PHP   6. Directus\Console\Common\Setting->__construct() webrootsrc/core/Directus/Console/Modules/InstallModule.php:186
```