### PR TITLE
Fix response data contains json object instead of array

### DIFF
--- a/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -2290,7 +2290,7 @@ class RelationalTableGateway extends BaseTableGateway
             }
         }
 
-        return $entries;
+        return array_values($entries);
     }
 
     /**


### PR DESCRIPTION
If some foreign entries are soft-deleted, then it will be removed via `unset($entries[$key])` in line 2287

![image](https://user-images.githubusercontent.com/3615746/65668960-467e7980-e075-11e9-9b12-3cb1c798a74e.png)

This caused a strange bug in JSON response where `data` becomes JSON object instead of array, as shown below:
![image](https://user-images.githubusercontent.com/3615746/65669042-6f9f0a00-e075-11e9-8e26-1805d0f655c5.png)

This is because the `$entries` array becomes not sequential (after the `unset()`) - it has keys 0 and 2, but doesn't have 1 as a key as an example.

`json_encode` will only encode the PHP array as a JSON array if the PHP array is sequential - that is, if its keys are 0, 1, 2, 3, ...

[The solution is to reindex the array sequentially using the `array_values`](https://stackoverflow.com/a/18977473/2625955)
