### PR TITLE
Fix wrong chache naming.

### DIFF
--- a/src/core/Directus/Database/Schema/SchemaManager.php
+++ b/src/core/Directus/Database/Schema/SchemaManager.php
@@ -789,7 +789,7 @@ class SchemaManager
         // save the column into the data
         // @NOTE: this is the early implementation of cache
         // soon this will be change to cache
-        $this->data['tables'][$name] = $schema;
+        $this->data['collections'][$name] = $schema;
     }
 
     protected function addField(Field $column)


### PR DESCRIPTION
We have recently had some performance problem in GraphQL implementation in Directus, the main problem is described here: #1297 

Digging down in the code with the profiler I have noticed there are some methods that are call numbers grows exponentially when we increase fields.

In particular `\Directus\Database\Schema\SchemaManager::getCollection` search for entry with `collections.` prefix but the method `\Directus\Database\Schema\SchemaManager::addCollection` store it with `table` prefix.

This kind of cache works only on in the request context but gives really a huge benefit to the GraphQL schema building.

In our case, the improvement is 67% in time, and the memory footprint is ~4% less.

This fix doesn't change the caching behavior between requests, so if the database changes the changes are reflected in the schema, in the first request that hit the modified database.