### PR TITLE
add gitpod.io support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,36 @@
+image: gitpod/workspace-mysql
+
+tasks:
+  - init: >
+      composer install &&
+      cp config/api_sample.php config/api.php &&
+      echo "downloading demo database..." &&
+      curl https://directus.github.io/demo-sql/demo.sql > demo.sql &&
+      echo "please wait while demo database (demo.sql) is being imported..." &&
+      mysql -u root < gitpod-helper.sql &&
+      mysql -u root -p'root' directus < demo.sql &&
+      rm demo.sql
+
+    command: >
+      apachectl start &&
+      echo "######################################################################################################" &&
+      echo "#   " &&
+      echo "#   Your Directus Backend is now running! You can access it with a Directus App by the following url:" &&
+      echo "#   " &&
+      echo "#   $GITPOD_WORKSPACE_URL/_/" | sed -e 's/https:\/\//https:\/\/8001-/g' &&
+      echo "#   " &&
+      echo "#   Username: admin@example.com      Password: password" &&
+      echo "#   " &&
+      echo "#   " &&
+      echo "#   Quick access to Directus frontend app (choose 'other' in the api dropdown):" &&
+      echo "#   " &&
+      echo "#   Either use: https://directus.app/ " &&
+      echo "#   or" &&
+      echo "#   start a Directus App workspace: https://gitpod.io#https://github.com/directus/app"  &&
+      echo "#   " &&
+      echo "######################################################################################################"
+      
+
+ports:
+  - port: 8001
+

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ We love pull-requests! To work on Directus you'll need to install it locally fro
 * [Setup API Development Environment](https://docs.directus.io/advanced/source.html#api-source)
 * [Setup App Development Environment](https://docs.directus.io/advanced/source.html#application-source)
 
+If you want to dive right into the code and skip the manual setup of your development environment you can also spin up fully functional browser based development environments with a single click:
+
+* [Start API Gitpod Workspace](https://gitpod.io/#https://github.com/directus/api)
+* [Start APP Gitpod Workspace](https://gitpod.io/#https://github.com/directus/app)
+
 ### Sponsors
 
 [RANGER Studio](http://rangerstudio.com), Bas Jansen

--- a/gitpod-helper.sql
+++ b/gitpod-helper.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE IF NOT EXISTS directus;
+USE directus;
+SET PASSWORD FOR 'root'@'localhost' = PASSWORD('root');


### PR DESCRIPTION
I finally managed to add gitpod.io support for the api aswell.

Now we can spin up a fully functional develop environment for the api with just one click!
Try it yourself:  http://gitpod.io#https://github.com/PostPollux/api/tree/gitpod_support

It downloads all the dependencies, adds the api.php (copy of api_sample.php), downloads the demo.sql, creates the database, imports the demo.sql, deletes that demo.sql afterwards to keep things clean and finally starts the apache server.

It also nicely prints the url where you can reach your api and other help to keep things straight forward and easy.

The nice thing: If you stop your workspace and later start that one again (not spinning up a new one), all the dependencies and your sql data is already there, so it starts up really fast.
