### PR TITLE
Fix #1381 [Throwing 500 response code on mail sending fail]

### DIFF
--- a/src/core/Directus/Mail/Exception/MailNotSentException.php
+++ b/src/core/Directus/Mail/Exception/MailNotSentException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Directus\Mail\Exception;
+
+use Directus\Exception\ErrorExceptionInterface;
+use Directus\Exception\Exception;
+
+class MailNotSentException extends Exception implements ErrorExceptionInterface
+{
+    const ERROR_CODE = 503;
+
+    public function __construct()
+    {
+        parent::__construct("It seems like there's some issue when sending the mail. Please try again later.", static::ERROR_CODE);
+    }
+}

--- a/src/endpoints/Auth.php
+++ b/src/endpoints/Auth.php
@@ -19,6 +19,7 @@ use Directus\Services\UserSessionService;
 use Directus\Util\ArrayUtils;
 use Slim\Http\Cookies;
 use Directus\Database\TableGateway\DirectusUserSessionsTableGateway;
+use Directus\Mail\Exception\MailNotSentException;
 
 class Auth extends Route
 {
@@ -233,6 +234,7 @@ class Auth extends Route
             );
         } catch (\Exception $e) {
             $this->container->get('logger')->error($e);
+            throw new MailNotSentException();
         }
 
         return $this->responseWithData($request, $response, []);


### PR DESCRIPTION
When any exception throws by the swift mailer on sending the mail `Directus` will throw the 

```
error_code = 503
response_code = 500
```