### PR TITLE
Authenticate endpoint add 2FA exception

### DIFF
--- a/src/core/Directus/Application/Http/Middleware/AuthenticationMiddleware.php
+++ b/src/core/Directus/Application/Http/Middleware/AuthenticationMiddleware.php
@@ -47,7 +47,7 @@ class AuthenticationMiddleware extends AbstractMiddleware
 
         try {
             $user = $this->authenticate($request);
-            
+
             $hookEmitter = $this->container->get('hook_emitter');
             if (!$user && !$publicRoleId) {
                 $exception = new UserNotAuthenticatedException();
@@ -110,7 +110,7 @@ class AuthenticationMiddleware extends AbstractMiddleware
             $hookEmitter->run('auth.fail', [$exception]);
             throw $exception;
         }
-       
+
         // TODO: Adding an user should auto set its ID and GROUP
         // TODO: User data should be casted to its data type
         // TODO: Make sure that the group is not empty
@@ -139,7 +139,7 @@ class AuthenticationMiddleware extends AbstractMiddleware
 
             $user = $authService->authenticateWithToken($authToken, $request->getAttribute('ignore_origin'));
         }
-        
+
         return $user;
     }
 
@@ -226,8 +226,11 @@ class AuthenticationMiddleware extends AbstractMiddleware
 
         if ($num_elements > 3
             &&$target_array[$num_elements - 3] == 'users'
-            && $target_array[$num_elements - 2] == strval($id)
-            && $target_array[$num_elements - 1] == 'activate2FA') {
+            && (
+                $target_array[$num_elements - 2] == strval($id) ||
+                $target_array[$num_elements - 2] == 'me'
+            )
+            && $target_array[$num_elements - 1] == 'activate_2fa') {
             return true;
         }
 

--- a/src/core/Directus/Authentication/Exception/TFAEnforcedException.php
+++ b/src/core/Directus/Authentication/Exception/TFAEnforcedException.php
@@ -7,9 +7,10 @@ use Directus\Exception\UnauthorizedException;
 class TFAEnforcedException extends UnauthorizedException
 {
     const ERROR_CODE = 113;
+    const ERROR_MESSAGE = "2FA enforced but not activated for user";
 
     public function __construct()
     {
-        parent::__construct('2FA enforced but not activated for user');
+        parent::__construct(ERROR_MESSAGE);
     }
 }

--- a/src/core/Directus/Authentication/Provider.php
+++ b/src/core/Directus/Authentication/Provider.php
@@ -430,7 +430,7 @@ class Provider
      *
      * @return string
      */
-    public function generateAuthToken(UserInterface $user, $needs2FA = false)
+    public function generateAuthToken(UserInterface $user)
     {
         $payload = [
             'id' => (int) $user->getId(),
@@ -438,9 +438,6 @@ class Provider
             'exp' => $this->getNewExpirationTime()
         ];
 
-        if ($needs2FA == true) {
-            $payload['needs2FA'] = true;
-        }
 
         return $this->generateToken(JWTUtils::TYPE_AUTH, $payload);
     }

--- a/src/core/Directus/Services/AuthService.php
+++ b/src/core/Directus/Services/AuthService.php
@@ -353,16 +353,14 @@ class AuthService extends AbstractService
      *
      * @param UserInterface $user
      *
-     * @param bool $needs2FA Whether the user needs 2FA
-     *
      * @return string
      */
-    public function generateAuthToken(UserInterface $user, bool $needs2FA = false)
+    public function generateAuthToken(UserInterface $user)
     {
         /** @var Provider $auth */
         $auth = $this->container->get('auth');
 
-        return $auth->generateAuthToken($user, $needs2FA);
+        return $auth->generateAuthToken($user);
     }
 
     /**

--- a/src/core/Directus/Services/UsersService.php
+++ b/src/core/Directus/Services/UsersService.php
@@ -429,8 +429,8 @@ class UsersService extends AbstractService
     public function activate2FA($id, $tfa_secret, $otp)
     {
         $this->validate(
-            ['tfa_secret' => $tfa_secret, 'otp' => $otp],
-            ['tfa_secret' => 'required|string', 'otp' => 'required|string']
+            ['2fa_secret' => $tfa_secret, 'otp' => $otp],
+            ['2fa_secret' => 'required|string', 'otp' => 'required|string']
         );
 
         $ga = new Google2FA();

--- a/src/core/Directus/Services/UtilsService.php
+++ b/src/core/Directus/Services/UtilsService.php
@@ -69,6 +69,10 @@ class UtilsService extends AbstractService
     {
         $ga = new Google2FA();
         $tfa_secret = $ga->generateSecretKey();
-        return ['2fa_secret' => $tfa_secret];
+        return [
+            'data' => [
+                '2fa_secret' => $tfa_secret
+            ]
+        ];
     }
 }

--- a/src/endpoints/Auth.php
+++ b/src/endpoints/Auth.php
@@ -75,6 +75,7 @@ class Auth extends Route
             }
             unset($responseData['data']['user']);
         }
+        $responseData['data'] = !empty($responseData['data']) ? $responseData['data'] : null;
         return $this->responseWithData($request, $response, $responseData);
     }
 

--- a/src/endpoints/Users.php
+++ b/src/endpoints/Users.php
@@ -37,7 +37,7 @@ class Users extends Route
         $app->patch('/{id}/tracking/page', [$this, 'trackPage']);
 
         // Enable 2FA
-        $app->post('/{id}/activate2FA', [$this, 'activate2FA']);
+        $app->post('/{id}/activate_2fa', [$this, 'activate2FA']);
     }
 
     /**
@@ -135,7 +135,7 @@ class Users extends Route
         if (strpos($id, ',') !== false) {
             return $this->batch($request, $response);
         }
-      
+
         $responseData = $service->update(
             $id,
             $payload,
@@ -286,7 +286,7 @@ class Users extends Route
         $service = new UsersService($this->container);
         $responseData = $service->activate2FA(
             $request->getAttribute('id'),
-            $request->getParsedBodyParam('tfa_secret'),
+            $request->getParsedBodyParam('2fa_secret'),
             $request->getParsedBodyParam('otp')
         );
 


### PR DESCRIPTION
`Authenticate` endpoint will throw an error if 2FA is not enabled instead of encoding the needs2FA into the token.