### PR TITLE
added ability to authenticate on redis for caching

### DIFF
--- a/src/core/Directus/Application/CoreServicesProvider.php
+++ b/src/core/Directus/Application/CoreServicesProvider.php
@@ -925,6 +925,8 @@ class CoreServicesProvider
                     $host = (isset($poolConfig['host'])) ? $poolConfig['host'] : 'localhost';
                     $port = (isset($poolConfig['port'])) ? $poolConfig['port'] : 6379;
                     $socket = (isset($poolConfig['socket'])) ? $poolConfig['socket'] : null;
+                    $auth = (isset($poolConfig['auth'])) ? $poolConfig['auth'] : null;
+
                     if ($adapter == 'rediscluster') {
                         $client = new \RedisCluster(NULL,["$host:$port"]);
                     } else {
@@ -935,6 +937,11 @@ class CoreServicesProvider
                             $client->connect($host, $port);
                         }
                     }
+
+                    if ($auth) {
+                        $client->auth($auth);
+                    }
+
                     $pool = new RedisCachePool($client);
                 }
             }

--- a/src/core/Directus/Config/Schema/Schema.php
+++ b/src/core/Directus/Config/Schema/Schema.php
@@ -42,6 +42,7 @@ class Schema {
                     new Value('adapter', Types::STRING, 'filesystem'),
                     new Value('path', Types::STRING, '../cache/'),
                     new Value('host', Types::STRING, 'localhost'),
+                    new Value('auth', Types::STRING, null),
                     new Value('port', Types::INTEGER, 6379),
                 ])
             ]),


### PR DESCRIPTION
Hello there,

It seems there is no way to configure redis with a password. This is necessary on all redis versions starting on 3.2 when they're not running on localhost.

This pull request adds this ability.