### PR TITLE
Update FieldsConfig.php

### DIFF
--- a/src/core/Directus/GraphQL/FieldsConfig.php
+++ b/src/core/Directus/GraphQL/FieldsConfig.php
@@ -66,9 +66,9 @@ class FieldsConfig
                     $relation = $this->getRelation('o2m', $v['collection'], $v['field']);
                     $temp = [];
                     $temp['type'] = Types::listOf(Types::userCollection($relation['collection_one']));
-                    $temp['resolve'] = function ($value) use ($relation) {
+                     $temp['resolve'] = function ($value, $args, $context, $info) use ($relation) {
                         $data = [];
-                        foreach ($value[$relation['collection_one']] as  $v) {
+                        foreach ($value[$info->fieldName] as  $v) {
                             $data[] = $v[$relation['field_many']];
                         }
                         return $data;


### PR DESCRIPTION
Without this fix the GrapQL query brings values only in case when the M2M field has exactly the same name as the related collection. It can be ok, but for cases when it's required to have mutliple M2M fields pointing to the same collection, (e.g. there 2 collections  - games and tags, and so we need to specify Primary and Secondary tags for each game). So with current implementation we cannot create primaryTags and secondaryTag fields, we should use 'tags' field instead, but its only one, and we need 2. So this fix obtaining fieldName from parameters and using it for relation and not a collection name.
This code change related to the following bug: https://github.com/directus/api/issues/1412, and probably to that one too: https://github.com/directus/api/issues/1394