### PR TITLE
Revert "Fix issue when deleting a file and saving the item"

### DIFF
--- a/src/core/Directus/Services/AbstractService.php
+++ b/src/core/Directus/Services/AbstractService.php
@@ -204,7 +204,7 @@ abstract class AbstractService
 
         $constraints = [];
 
-        if (empty($fields)) {
+        if ($fields === null) {
             return $constraints;
         }
 


### PR DESCRIPTION
Reverts directus/api#1360 - This PR is the culprit for failure of `required` validation. Reverting back to make them work again. 