### PR TITLE
Fix Constant Imagick::ALPHACHANNEL_REMOVE is undefined

### DIFF
--- a/src/core/Directus/Filesystem/Thumbnail.php
+++ b/src/core/Directus/Filesystem/Thumbnail.php
@@ -121,8 +121,17 @@ class Thumbnail
         $image->setIteratorIndex(0);
         $image->setImageFormat($format);
         $image->setImageBackgroundColor('#ffffff');
-        $image->setImageAlphaChannel(\Imagick::ALPHACHANNEL_REMOVE);
+        
+        // Only Imagick 3.4.4 contains the ALPHACHANNEL_REMOVE constant
+        if(\Imagick::IMAGICK_EXTNUM >= 30404){
+            $image->setImageAlphaChannel(\Imagick::ALPHACHANNEL_REMOVE);
+        }
+        else{
+            $image->setImageAlphaChannel(12);
+        }
+        
         $image = $image->mergeImageLayers(\Imagick::LAYERMETHOD_FLATTEN);
+        
         return $image->getImageBlob();
     }
 


### PR DESCRIPTION
When using Imagick less than version 3.4.4, it will throw error `Constant Imagick::ALPHACHANNEL_REMOVE is undefined` when uploading non-image format such as PDF and in effect the PDF's thumbnail will respond with HTTP error 5XX

The const `ALPHACHANNEL_REMOVE` only exist in 3.4.4 as described [here](https://github.com/Imagick/imagick/issues/281).