### PR TITLE
Stop migrations execution for server endpoints

### DIFF
--- a/src/endpoints/Server.php
+++ b/src/endpoints/Server.php
@@ -19,12 +19,14 @@ class Server extends Route
     public function __invoke(Application $app)
     {
         \Directus\create_ping_route($app);
-        $app->get('/projects', [$this, 'projects']);
         $app->get('/info', [$this, 'getInfo']);
-        $app->group('/projects', function () {
+        $controller = $this;
+        $app->group('/projects', function () use ($controller){
+            $this->get("/",[$controller, 'projects']);
             $this->post('/', \Directus\Api\Routes\ProjectsCreate::class);
             $this->delete('/{name}', \Directus\Api\Routes\ProjectsDelete::class);
         })->add(new TableGatewayMiddleware($this->container));
+         
     }
 
     /**

--- a/src/endpoints/Server.php
+++ b/src/endpoints/Server.php
@@ -22,7 +22,7 @@ class Server extends Route
         $app->get('/info', [$this, 'getInfo']);
         $controller = $this;
         $app->group('/projects', function () use ($controller){
-            $this->get("/",[$controller, 'projects']);
+            $this->get('',[$controller, 'projects']);
             $this->post('/', \Directus\Api\Routes\ProjectsCreate::class);
             $this->delete('/{name}', \Directus\Api\Routes\ProjectsDelete::class);
         })->add(new TableGatewayMiddleware($this->container));

--- a/src/web.php
+++ b/src/web.php
@@ -127,11 +127,11 @@ $middleware = [
 $app->add($middleware['rate_limit_ip'])
     ->add($middleware['proxy'])
     ->add($middleware['ip'])
-    ->add($middleware['database_migration'])
     ->add($middleware['cors']);
 
 $app->get('/', \Directus\Api\Routes\Home::class)
     ->add($middleware['rate_limit_user'])
+    ->add($middleware['database_migration'])
     ->add($middleware['table_gateway']);
 
 
@@ -254,30 +254,34 @@ $app->group('/{project}', function () use ($middleware) {
         ->add($middleware['rate_limit_user'])
         ->add($middleware['auth'])
         ->add($middleware['table_gateway']);
-});
+})->add($middleware['database_migration']);
 
 $app->group('/interfaces', \Directus\Api\Routes\Interfaces::class)
     ->add($middleware['rate_limit_user'])
     ->add($middleware['auth_user'])
     ->add($middleware['auth'])
-    ->add($middleware['table_gateway']);
+    ->add($middleware['table_gateway'])
+    ->add($middleware['database_migration']);
 $app->group('/layouts', \Directus\Api\Routes\Layouts::class)
     ->add($middleware['rate_limit_user'])
     ->add($middleware['auth_user'])
     ->add($middleware['auth'])
-    ->add($middleware['table_gateway']);
+    ->add($middleware['table_gateway'])
+    ->add($middleware['database_migration']);
 $app->group('/pages', \Directus\Api\Routes\Pages::class)
     ->add($middleware['rate_limit_user'])
     ->add($middleware['auth_user'])
     ->add($middleware['auth'])
-    ->add($middleware['table_gateway']);
+    ->add($middleware['table_gateway'])
+    ->add($middleware['database_migration']);
    
 $app->group('/server', \Directus\Api\Routes\Server::class);
 $app->group('/types', \Directus\Api\Routes\Types::class)
     ->add($middleware['rate_limit_user'])
     ->add($middleware['auth_user'])
     ->add($middleware['auth'])
-    ->add($middleware['table_gateway']);
+    ->add($middleware['table_gateway'])
+    ->add($middleware['database_migration']);
 
 $app->add(new \Directus\Application\Http\Middleware\ResponseCacheMiddleware($app->getContainer()));
 


### PR DESCRIPTION
`/ping` endpoint was executing the migrations if the `project-name` was given in the request.
This PR will stop the execution of migrations for all the `/server` related endpoints.