### PR TITLE
Remove check for libapache2_mod_php

### DIFF
--- a/src/endpoints/Server.php
+++ b/src/endpoints/Server.php
@@ -86,7 +86,6 @@ class Server extends Route
                     'curl' => extension_loaded("curl"),
                     'gd' => extension_loaded("gd"),
                     'fileinfo' => extension_loaded("fileinfo"),
-                    'libapache2_mod_php' => extension_loaded("libapache2-mod-php"),
                     'mbstring' => extension_loaded("mbstring"),
                     'json' => extension_loaded("json"),
                 ],


### PR DESCRIPTION
The Apache PHP module is needed in order to run PHP from Apache. This information is returned from PHP, so if this module isn't loaded, this whole endpoint wouldn't do anything. If this endpoint works, we already know that libapache2-mod-php is working as expected. (Also, extension_loaded("libapache2-mod-php") never seems to be true.