### PR TITLE
Fix #1483 [activity_skip doesnt work on delete file]

### DIFF
--- a/src/core/Directus/Services/FilesServices.php
+++ b/src/core/Directus/Services/FilesServices.php
@@ -124,7 +124,7 @@ class FilesServices extends AbstractService
         $files->delete($file);
 
         // Delete file record
-        return $tableGateway->deleteRecord($id);
+        return $tableGateway->deleteRecord($id,$this->getCRUDParams($params));
     }
 
     public function findAll(array $params = [])


### PR DESCRIPTION
Fixes #1483

The issue replicates for the `delete` request only. Not able to replicate for `post` or `patch`.