### PR TITLE
Check if array keys exist before use and pass filename_disk where needed

### DIFF
--- a/src/helpers/file.php
+++ b/src/helpers/file.php
@@ -148,6 +148,7 @@ if (!function_exists('append_storage_information')) {
             // Add thumbnails if the asset is an image
             $search = 'image';
             if (
+                array_key_exists('type', $row) &&
                 substr($row['type'], 0, strlen($search)) === $search &&
                 $row['type'] !== 'image/svg+xml' // SVGs aren't manipulatable bitmaps
             ) {


### PR DESCRIPTION
Fixes the `PATCH /files/{id}` endpoint when the user doesn't pass the `filename_disk` and/or when using PHP strict mode