### PR TITLE
Return the relative url of thumbnails including root folder

### DIFF
--- a/src/helpers/all.php
+++ b/src/helpers/all.php
@@ -154,6 +154,21 @@ if (!function_exists('get_url')) {
     }
 }
 
+if (!function_exists('get_base_path')) {
+    /**
+     * Get Directus' base path
+     *
+     * If Directus is running in a folder, this will return the names of the folder
+     * that Directus is running in, f.e. /directus/public/
+     *
+     * @return string
+     */
+    function get_base_path()
+    {
+        return create_uri_from_global()->getBasePath() . '/';
+    }
+}
+
 if (!function_exists('create_request_from_global')) {
     /**
      * Create a Request object from global variables

--- a/src/helpers/file.php
+++ b/src/helpers/file.php
@@ -262,21 +262,14 @@ if (!function_exists('get_thumbnail_path')) {
      *
      * @return string
      */
-    function get_thumbnail_path($name,$thumbnail)
+    function get_thumbnail_path($name, $thumbnail)
     {
+        $basePath = get_base_path();
         $projectName = get_api_project_from_request();
 
-        $thumbnailDetail=$thumbnail;
+        $paramsString = '?key=' . $thumbnail['key'];
 
-        $paramsString=  '?key='.$thumbnailDetail['key'];
-
-        return sprintf(
-            '/%s/%s/%s%s',
-            $projectName,
-            'assets',
-            $name,
-            $paramsString
-        );
+        return $basePath . $projectName . '/assets/' . $name . $paramsString;
     }
 }
 


### PR DESCRIPTION
The thumbnail relative URL was hardcoded to be returned as `/assets/etc`. However, when you run Directus inside of a folder, this should be prepended by the location of Directus itself, for example `/directus/public/assets/etc`. 