### PR TITLE
Rename User-Created Interface to Owner

### DIFF
--- a/migrations/install/20180220023208_create_files_table.php
+++ b/migrations/install/20180220023208_create_files_table.php
@@ -4,7 +4,7 @@ use Phinx\Migration\AbstractMigration;
 
 class CreateFilesTable extends AbstractMigration
 {
-   /**
+    /**
      * Create Files Table
      */
     public function change()
@@ -162,7 +162,7 @@ class CreateFilesTable extends AbstractMigration
                 'type' => \Directus\Database\Schema\DataTypes::TYPE_STRING,
                 'interface' => 'wysiwyg',
                 'options' => json_encode([
-                    'toolbar' => ['bold','italic','underline','link','code']
+                    'toolbar' => ['bold', 'italic', 'underline', 'link', 'code']
                 ]),
                 'sort' => 5,
                 'width' => 'full',
@@ -198,7 +198,7 @@ class CreateFilesTable extends AbstractMigration
                 'collection' => 'directus_files',
                 'field' => 'private_hash',
                 'type' => \Directus\Database\Schema\DataTypes::TYPE_STRING,
-                'interface'=> 'slug',
+                'interface' => 'slug',
                 'width' => 'half',
                 'locked' => 1,
                 'sort' => 8,
@@ -237,8 +237,8 @@ class CreateFilesTable extends AbstractMigration
             [
                 'collection' => 'directus_files',
                 'field' => 'uploaded_by',
-                'type' => \Directus\Database\Schema\DataTypes::TYPE_USER_CREATED,
-                'interface' => 'user-created',
+                'type' => \Directus\Database\Schema\DataTypes::TYPE_OWNER,
+                'interface' => 'owner',
                 'locked' => 1,
                 'readonly' => 1,
                 'sort' => 11,
@@ -384,15 +384,16 @@ class CreateFilesTable extends AbstractMigration
             ]
         ];
 
-        foreach($data as $value){
-            if(!$this->checkFieldExist($value['collection'], $value['field'])){
+        foreach ($data as $value) {
+            if (!$this->checkFieldExist($value['collection'], $value['field'])) {
                 $fileds = $this->table('directus_fields');
                 $fileds->insert($value)->save();
             }
         }
     }
 
-    public function checkFieldExist($collection,$field){
+    public function checkFieldExist($collection, $field)
+    {
         $checkSql = sprintf('SELECT 1 FROM `directus_fields` WHERE `collection` = "%s" AND `field` = "%s";', $collection, $field);
         return $this->query($checkSql)->fetch();
     }

--- a/migrations/upgrades/20191220102232_update_user_created_to_owner.php
+++ b/migrations/upgrades/20191220102232_update_user_created_to_owner.php
@@ -18,10 +18,4 @@ class UpdateUserCreatedToOwner extends AbstractMigration
             ['type' =>  'user_created']
         ));
     }
-
-    public function checkFieldExist($collection, $field)
-    {
-        $checkSql = sprintf('SELECT 1 FROM `directus_fields` WHERE `collection` = "%s" AND `field` = "%s";', $collection, $field);
-        return $this->query($checkSql)->fetch();
-    }
 }

--- a/migrations/upgrades/20191220102232_update_user_created_to_owner.php
+++ b/migrations/upgrades/20191220102232_update_user_created_to_owner.php
@@ -1,0 +1,40 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class UpdateUserCreatedToOwner extends AbstractMigration
+{
+    public function change()
+    {
+        if ($this->checkFieldExist('directus_files', 'uploaded_by')) {
+            $this->execute(\Directus\phinx_update(
+                $this->getAdapter(),
+                'directus_fields',
+                [
+                    'type' => \Directus\Database\Schema\DataTypes::TYPE_OWNER,
+                    'interface' => 'owner'
+                ],
+                ['collection' => 'directus_files', 'field' => 'uploaded_by']
+            ));
+        }
+
+
+        // To change the type of all the field of user generated collection to owner
+        $this->execute(\Directus\phinx_update(
+            $this->getAdapter(),
+            'directus_fields',
+            [
+                'type' => \Directus\Database\Schema\DataTypes::TYPE_OWNER,
+                'interface' => 'owner'
+            ],
+            ['type' =>  'user_created']
+        ));
+    }
+
+    public function checkFieldExist($collection, $field)
+    {
+        $checkSql = sprintf('SELECT 1 FROM `directus_fields` WHERE `collection` = "%s" AND `field` = "%s";', $collection, $field);
+        return $this->query($checkSql)->fetch();
+    }
+}

--- a/migrations/upgrades/20191220102232_update_user_created_to_owner.php
+++ b/migrations/upgrades/20191220102232_update_user_created_to_owner.php
@@ -7,19 +7,6 @@ class UpdateUserCreatedToOwner extends AbstractMigration
 {
     public function change()
     {
-        if ($this->checkFieldExist('directus_files', 'uploaded_by')) {
-            $this->execute(\Directus\phinx_update(
-                $this->getAdapter(),
-                'directus_fields',
-                [
-                    'type' => \Directus\Database\Schema\DataTypes::TYPE_OWNER,
-                    'interface' => 'owner'
-                ],
-                ['collection' => 'directus_files', 'field' => 'uploaded_by']
-            ));
-        }
-
-
         // To change the type of all the field of user generated collection to owner
         $this->execute(\Directus\phinx_update(
             $this->getAdapter(),

--- a/migrations/upgrades/20191220102232_update_user_created_to_owner.php
+++ b/migrations/upgrades/20191220102232_update_user_created_to_owner.php
@@ -11,11 +11,15 @@ class UpdateUserCreatedToOwner extends AbstractMigration
         $this->execute(\Directus\phinx_update(
             $this->getAdapter(),
             'directus_fields',
-            [
-                'type' => \Directus\Database\Schema\DataTypes::TYPE_OWNER,
-                'interface' => 'owner'
-            ],
+            ['type' => \Directus\Database\Schema\DataTypes::TYPE_OWNER],
             ['type' =>  'user_created']
+        ));
+
+        $this->execute(\Directus\phinx_update(
+            $this->getAdapter(),
+            'directus_fields',
+            ['interface' => 'owner'],
+            ['interface' => 'user_created']
         ));
     }
 }

--- a/src/core/Directus/Database/Schema/DataTypes.php
+++ b/src/core/Directus/Database/Schema/DataTypes.php
@@ -28,7 +28,7 @@ final class DataTypes
     const TYPE_UUID                 = 'uuid';
     const TYPE_DATETIME_CREATED     = 'datetime_created';
     const TYPE_DATETIME_UPDATED     = 'datetime_updated';
-    const TYPE_USER_CREATED         = 'user_created';
+    const TYPE_OWNER                = 'owner';
     const TYPE_USER_UPDATED         = 'user_updated';
     const TYPE_USER                 = 'user';
 
@@ -64,7 +64,7 @@ final class DataTypes
             static::TYPE_UUID,
             static::TYPE_DATETIME_CREATED,
             static::TYPE_DATETIME_UPDATED,
-            static::TYPE_USER_CREATED,
+            static::TYPE_OWNER,
             static::TYPE_USER_UPDATED,
             static::TYPE_USER,
         ];
@@ -335,7 +335,7 @@ final class DataTypes
     public static function getSystemUserType()
     {
         return [
-            static::TYPE_USER_CREATED,
+            static::TYPE_OWNER,
             static::TYPE_USER_UPDATED
         ];
     }
@@ -386,7 +386,7 @@ final class DataTypes
     public static function getUniqueTypes()
     {
         return array_merge([
-            static::TYPE_USER_CREATED,
+            static::TYPE_OWNER,
             static::TYPE_USER_UPDATED,
             static::TYPE_STATUS,
             static::TYPE_SORT,
@@ -436,7 +436,7 @@ final class DataTypes
     public static function getUsersType()
     {
         return [
-            static::TYPE_USER_CREATED,
+            static::TYPE_OWNER,
             static::TYPE_USER_UPDATED,
             static::TYPE_USER,
         ];

--- a/src/core/Directus/Database/Schema/Object/Collection.php
+++ b/src/core/Directus/Database/Schema/Object/Collection.php
@@ -95,7 +95,7 @@ class Collection extends AbstractObject
                 $this->statusField = $field;
             } else if (!$this->getDateCreatedField() && $field->isDateCreatedType()) {
                 $this->dateCreatedField = $field;
-            } else if (!$this->getUserCreatedField() && $field->isUserCreatedType()) {
+            } else if (!$this->getUserCreatedField() && $field->isOwnerType()) {
                 $this->userCreatedField = $field;;
             } else if (!$this->getDateModifiedField() && $field->isDateModifiedType()) {
                 $this->dateModifiedField = $field;
@@ -123,7 +123,7 @@ class Collection extends AbstractObject
         $fields = $this->fields;
 
         if ($names) {
-            $fields = array_filter($fields, function(Field $field) use ($names) {
+            $fields = array_filter($fields, function (Field $field) use ($names) {
                 return in_array($field->getName(), $names);
             });
         }
@@ -143,7 +143,7 @@ class Collection extends AbstractObject
         $fields = $this->fields;
 
         if ($names) {
-            $fields = array_filter($fields, function(Field $field) use ($names) {
+            $fields = array_filter($fields, function (Field $field) use ($names) {
                 return !in_array($field->getName(), $names);
             });
         }
@@ -183,7 +183,7 @@ class Collection extends AbstractObject
      */
     public function getFieldsArray()
     {
-        return array_map(function(Field $field) {
+        return array_map(function (Field $field) {
             return $field->toArray();
         }, $this->getFields());
     }
@@ -225,7 +225,7 @@ class Collection extends AbstractObject
      */
     public function getNonRelationalFields(array $names = [])
     {
-        return array_filter($this->getFields($names), function(Field $field) {
+        return array_filter($this->getFields($names), function (Field $field) {
             return !$field->hasRelationship();
         });
     }
@@ -237,7 +237,7 @@ class Collection extends AbstractObject
      */
     public function getAliasFields()
     {
-        return array_filter($this->getFields(), function(Field $field) {
+        return array_filter($this->getFields(), function (Field $field) {
             return $field->isAlias();
         });
     }
@@ -249,7 +249,7 @@ class Collection extends AbstractObject
      */
     public function getNonAliasFields()
     {
-        return array_filter($this->getFields(), function(Field $field) {
+        return array_filter($this->getFields(), function (Field $field) {
             return !$field->isAlias();
         });
     }
@@ -261,7 +261,7 @@ class Collection extends AbstractObject
      */
     public function getFieldsName()
     {
-        return array_map(function(Field $field) {
+        return array_map(function (Field $field) {
             return $field->getName();
         }, $this->getFields());
     }
@@ -285,7 +285,7 @@ class Collection extends AbstractObject
      */
     public function getAliasFieldsName()
     {
-        return array_map(function(Field $field) {
+        return array_map(function (Field $field) {
             return $field->getName();
         }, $this->getAliasFields());
     }
@@ -297,7 +297,7 @@ class Collection extends AbstractObject
      */
     public function getNonAliasFieldsName()
     {
-        return array_map(function(Field $field) {
+        return array_map(function (Field $field) {
             return $field->getName();
         }, $this->getNonAliasFields());
     }
@@ -409,7 +409,7 @@ class Collection extends AbstractObject
      */
     public function isHidden()
     {
-        return (bool)$this->attributes->get('hidden');
+        return (bool) $this->attributes->get('hidden');
     }
 
     /**

--- a/src/core/Directus/Database/Schema/Object/Field.php
+++ b/src/core/Directus/Database/Schema/Object/Field.php
@@ -377,9 +377,9 @@ class Field extends AbstractObject
      *
      * @return bool
      */
-    public function isUserCreatedType()
+    public function isOwnerType()
     {
-        return $this->isType(DataTypes::TYPE_USER_CREATED);
+        return $this->isType(DataTypes::TYPE_OWNER);
     }
 
     /**

--- a/src/core/Directus/GraphQL/FieldsConfig.php
+++ b/src/core/Directus/GraphQL/FieldsConfig.php
@@ -69,7 +69,7 @@ class FieldsConfig
                     $relation = $this->getRelation('o2m', $v['collection'], $v['field']);
                     $temp = [];
                     $temp['type'] = Types::listOf(Types::userCollection($relation['collection_one']));
-                     $temp['resolve'] = function ($value, $args, $context, $info) use ($relation) {
+                    $temp['resolve'] = function ($value, $args, $context, $info) use ($relation) {
                         $data = [];
                         foreach ($value[$info->fieldName] as  $v) {
                             $data[] = $v[$relation['field_many']];
@@ -91,7 +91,7 @@ class FieldsConfig
                     $relation = $this->getRelation('translation', $v['collection'], $v['field']);
                     $fields[$v['field']] = Types::listOf(Types::userCollection($relation['collection_many']));
                     break;
-                case 'user_created':
+                case 'owner':
                 case 'user_updated':
                     $fields[$v['field']] = Types::directusUser();
                     break;


### PR DESCRIPTION
This PR will rename `user_created` interface to `owner`  as discussed in https://github.com/directus/api/issues/1567

But it'll not make it editable. Please let me know if we should make them editable.