### PR TITLE
Fix #1574 [Return warnings / notices in API when doing something that is impossible]

### DIFF
--- a/src/core/Directus/Exception/ErrorCodes.php
+++ b/src/core/Directus/Exception/ErrorCodes.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Directus\Exception;
+
+class ErrorCodes
+{
+    const WARNING_ACCESS_DENIED = 18;
+}


### PR DESCRIPTION
Fixes #1574

Return the notice if the relational [O2M/M2O] field doesn't have access to read the collection - only for the development environment. 