### PR TITLE
Fix #1523 [Issue with TableGatewayFactory and ACL in Endpoints]

### DIFF
--- a/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -1789,11 +1789,13 @@ class RelationalTableGateway extends BaseTableGateway
             //Logic for blacklisted fields
             $field = explode('.', $column);
             $field = array_shift($field);
-            $fieldReadBlackListDetails = $this->acl->getStatusesOnReadFieldBlacklist($this->getTable(), $field);
-            if (isset($fieldReadBlackListDetails['isReadBlackList']) && $fieldReadBlackListDetails['isReadBlackList']) {
-                throw new Exception\ForbiddenFieldAccessException($field);
-            } else if (isset($fieldReadBlackListDetails['statuses']) && !empty($fieldReadBlackListDetails['statuses'])) {
-                $blackListStatuses = array_merge($blackListStatuses, array_values($fieldReadBlackListDetails['statuses']));
+            if ($this->acl) {
+                $fieldReadBlackListDetails = $this->acl->getStatusesOnReadFieldBlacklist($this->getTable(), $field);
+                if (isset($fieldReadBlackListDetails['isReadBlackList']) && $fieldReadBlackListDetails['isReadBlackList']) {
+                    throw new Exception\ForbiddenFieldAccessException($field);
+                } else if (isset($fieldReadBlackListDetails['statuses']) && !empty($fieldReadBlackListDetails['statuses'])) {
+                    $blackListStatuses = array_merge($blackListStatuses, array_values($fieldReadBlackListDetails['statuses']));
+                }
             }
 
             if (!(!is_string($column) || strpos($column, '.') === false)) {


### PR DESCRIPTION
Fixes #1523.

Conclusion; when `ACL` is set as `false` user will get the result; though the `public` permission is not set. As permissions depend on `ACL` only and if it's `false` then we don't have any access of `permission`.

@rijkvanzanten - Please correct me if I misunderstood anything. 