### PR TITLE
Fallback to cookie on empty authorization headers

### DIFF
--- a/src/helpers/all.php
+++ b/src/helpers/all.php
@@ -25,33 +25,32 @@ use Slim\Http\UploadedFile;
 use Slim\Http\Uri;
 use Directus\Authentication\Exception\InvalidTokenException;
 
-
 const TOKEN_CIPHER_METHOD = 'aes-128-ctr';
 
-require __DIR__ . '/constants.php';
-require __DIR__ . '/app.php';
-require __DIR__ . '/arrays.php';
-require __DIR__ . '/bytes.php';
-require __DIR__ . '/cors.php';
-require __DIR__ . '/extensions.php';
-require __DIR__ . '/file.php';
-require __DIR__ . '/items.php';
-require __DIR__ . '/mail.php';
-require __DIR__ . '/regex.php';
-require __DIR__ . '/request.php';
-require __DIR__ . '/server.php';
-require __DIR__ . '/settings.php';
-require __DIR__ . '/sorting.php';
-require __DIR__ . '/url.php';
-require __DIR__ . '/uuid.php';
+require __DIR__.'/constants.php';
+require __DIR__.'/app.php';
+require __DIR__.'/arrays.php';
+require __DIR__.'/bytes.php';
+require __DIR__.'/cors.php';
+require __DIR__.'/extensions.php';
+require __DIR__.'/file.php';
+require __DIR__.'/items.php';
+require __DIR__.'/mail.php';
+require __DIR__.'/regex.php';
+require __DIR__.'/request.php';
+require __DIR__.'/server.php';
+require __DIR__.'/settings.php';
+require __DIR__.'/sorting.php';
+require __DIR__.'/url.php';
+require __DIR__.'/uuid.php';
 
 if (!function_exists('uc_convert')) {
     /**
-     * Converts a string to title
+     * Converts a string to title.
      *
-     * @param string $text The string to convert.
+     * @param string $text the string to convert
      *
-     * @return string Formatted string.
+     * @return string formatted string
      */
     function uc_convert($text)
     {
@@ -86,13 +85,13 @@ if (!function_exists('uc_convert')) {
             'Csv' => 'CSV',
             'Ios' => 'iOS',
             'Iso' => 'ISO',
-            'Rngr' => 'RNGR'
+            'Rngr' => 'RNGR',
         ];
 
         $searchPattern = array_keys($specialCaps);
         $replaceValues = array_values($specialCaps);
         foreach ($searchPattern as $key => $value) {
-            $searchPattern[$key] = ("/\b" . $value . "\b/");
+            $searchPattern[$key] = ("/\b".$value."\b/");
         }
 
         return preg_replace($searchPattern, $replaceValues, $phrase);
@@ -101,7 +100,7 @@ if (!function_exists('uc_convert')) {
 
 if (!function_exists('get_directus_path')) {
     /**
-     * Gets the Directus path (subdirectory based on the host)
+     * Gets the Directus path (subdirectory based on the host).
      *
      * @param string $subPath
      *
@@ -114,7 +113,7 @@ if (!function_exists('get_directus_path')) {
         $path = trim($path, '/');
         $subPath = ltrim($subPath, '/');
 
-        return (empty($path) ? '/' : sprintf('/%s/', $path)) . $subPath;
+        return (empty($path) ? '/' : sprintf('/%s/', $path)).$subPath;
     }
 }
 
@@ -127,9 +126,9 @@ if (!function_exists('normalize_path')) {
      *
      * from WordPress source code
      *
-     * @param string $path Path to normalize.
+     * @param string $path path to normalize
      *
-     * @return string Normalized path.
+     * @return string normalized path
      */
     function normalize_path($path)
     {
@@ -142,7 +141,7 @@ if (!function_exists('normalize_path')) {
 
 if (!function_exists('get_url')) {
     /**
-     * Get Directus URL
+     * Get Directus URL.
      *
      * @param $path - Extra path to add to the url
      *
@@ -150,13 +149,13 @@ if (!function_exists('get_url')) {
      */
     function get_url($path = '')
     {
-        return create_uri_from_global()->getBaseUrl() . '/' . ltrim($path, '/');
+        return create_uri_from_global()->getBaseUrl().'/'.ltrim($path, '/');
     }
 }
 
 if (!function_exists('get_base_path')) {
     /**
-     * Get Directus' base path
+     * Get Directus' base path.
      *
      * If Directus is running in a folder, this will return the names of the folder
      * that Directus is running in, f.e. /directus/public/
@@ -165,13 +164,13 @@ if (!function_exists('get_base_path')) {
      */
     function get_base_path()
     {
-        return create_uri_from_global()->getBasePath() . '/';
+        return create_uri_from_global()->getBasePath().'/';
     }
 }
 
 if (!function_exists('create_request_from_global')) {
     /**
-     * Create a Request object from global variables
+     * Create a Request object from global variables.
      *
      * @param array $options
      *
@@ -216,7 +215,7 @@ if (!function_exists('create_request_from_global')) {
 
 if (!function_exists('create_uri_from_global')) {
     /**
-     * Creates a uri object based on $_SERVER
+     * Creates a uri object based on $_SERVER.
      *
      * Snippet copied from Slim URI class
      *
@@ -237,7 +236,7 @@ if (!function_exists('create_uri_from_global')) {
 
 if (!function_exists('get_virtual_path')) {
     /**
-     * Gets the virtual request path
+     * Gets the virtual request path.
      *
      * @return string
      */
@@ -249,7 +248,7 @@ if (!function_exists('get_virtual_path')) {
 
 if (!function_exists('get_api_project_from_request')) {
     /**
-     * Gets the project name from the request uri
+     * Gets the project name from the request uri.
      *
      * @return string
      */
@@ -294,11 +293,11 @@ if (!function_exists('get_api_project_from_request')) {
 
 if (!function_exists('get_request_authorization_token')) {
     /**
-     * Returns the authorization token from a request object
+     * Returns the authorization token from a request object.
      *
      * @param Request $request
      *
-     * @return null|string
+     * @return string|null
      */
     function get_request_authorization_token(Request $request)
     {
@@ -363,26 +362,27 @@ if (!function_exists('get_request_authorization_token')) {
 
 if (!function_exists('get_project_session_cookie_name')) {
     /**
-     * Returns the session cookie name of current project
+     * Returns the session cookie name of current project.
      *
      * @param Request $request
      *
-     * @return null|string
+     * @return string|null
      */
     function get_project_session_cookie_name($request)
     {
         $projectName = get_api_project_from_request($request);
-        return 'directus-' . $projectName . '-session';
+
+        return 'directus-'.$projectName.'-session';
     }
 }
 
 if (!function_exists('get_static_token_based_on_type')) {
     /**
-     * Returns the static token of users table from a encrypted token of sessions table
+     * Returns the static token of users table from a encrypted token of sessions table.
      *
      * @param Request $request
      *
-     * @return null|string
+     * @return string|null
      */
     function get_static_token_based_on_type($tokenObject)
     {
@@ -406,58 +406,61 @@ if (!function_exists('get_static_token_based_on_type')) {
                     break;
             }
         }
+
         return $accessToken;
     }
 }
 
 if (!function_exists('encrypt_static_token')) {
     /**
-     * Returns the encrypted static token
+     * Returns the encrypted static token.
      *
      * @param Request $request
      *
-     * @return null|string
+     * @return string|null
      */
     function encrypt_static_token($token)
     {
-        $enc_key = openssl_digest(php_uname(), 'SHA256', TRUE);
+        $enc_key = openssl_digest(php_uname(), 'SHA256', true);
         $enc_iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length(TOKEN_CIPHER_METHOD));
-        $cryptedToken = openssl_encrypt($token, TOKEN_CIPHER_METHOD, $enc_key, 0, $enc_iv) . "::" . bin2hex($enc_iv);
+        $cryptedToken = openssl_encrypt($token, TOKEN_CIPHER_METHOD, $enc_key, 0, $enc_iv).'::'.bin2hex($enc_iv);
+
         return $cryptedToken;
     }
 }
 
 if (!function_exists('decrypt_static_token')) {
     /**
-     * Returns the decrypted static token
+     * Returns the decrypted static token.
      *
      * @param Request $request
      *
-     * @return null|string
+     * @return string|null
      */
     function decrypt_static_token($token)
     {
-        list($cryptedToken, $enc_iv) = explode("::", $token);
-        $enc_key = openssl_digest(php_uname(), 'SHA256', TRUE);
+        list($cryptedToken, $enc_iv) = explode('::', $token);
+        $enc_key = openssl_digest(php_uname(), 'SHA256', true);
         $token = openssl_decrypt($cryptedToken, TOKEN_CIPHER_METHOD, $enc_key, 0, hex2bin($enc_iv));
+
         return $token;
     }
 }
 
 if (!function_exists('get_request_project_name')) {
     /**
-     * Returns the project name from a request object
+     * Returns the project name from a request object.
      *
      * @param Request $request
      *
-     * @return null|string
+     * @return string|null
      */
     function get_request_project_name(Request $request)
     {
         $name = null;
         if ($request->getQueryParam('project')) {
             $name = $request->getQueryParam('project');
-        } else if ($request->hasHeader('X-Directus-Project')) {
+        } elseif ($request->hasHeader('X-Directus-Project')) {
             $name = $request->getHeader('X-Directus-Project');
         }
 
@@ -467,10 +470,10 @@ if (!function_exists('get_request_project_name')) {
 
 if (!function_exists('create_config_path')) {
     /**
-     * Creates the configuration path for a project
+     * Creates the configuration path for a project.
      *
-     * @param string $basePath
-     * @param null|string $project
+     * @param string      $basePath
+     * @param string|null $project
      *
      * @return string
      */
@@ -482,7 +485,7 @@ if (!function_exists('create_config_path')) {
 
 if (!function_exists('create_maintenanceflag_path')) {
     /**
-     * Returns the path for the maintenance flag file
+     * Returns the path for the maintenance flag file.
      *
      * @param string $basePath
      *
@@ -490,13 +493,13 @@ if (!function_exists('create_maintenanceflag_path')) {
      */
     function create_maintenanceflag_path($basePath)
     {
-        return $basePath . '/logs/maintenance';
+        return $basePath.'/logs/maintenance';
     }
 }
 
 if (!function_exists('get_reserved_endpoint_names')) {
     /**
-     * Returns a list of reserved endpoint names
+     * Returns a list of reserved endpoint names.
      *
      * @return array
      */
@@ -508,14 +511,14 @@ if (!function_exists('get_reserved_endpoint_names')) {
             'modules',
             'layouts',
             'types',
-            'projects'
+            'projects',
         ];
     }
 }
 
 if (!function_exists('get_file_info')) {
     /**
-     * Get info about a file, return extensive information about images (more to come)
+     * Get info about a file, return extensive information about images (more to come).
      *
      * @return array File info
      */
@@ -546,10 +549,10 @@ if (!function_exists('get_file_info')) {
 
 if (!function_exists('template')) {
     /**
-     * Renders a single line. Looks for {{ var }}
+     * Renders a single line. Looks for {{ var }}.
      *
      * @param string $string
-     * @param array $parameters
+     * @param array  $parameters
      *
      * @return string
      */
@@ -569,7 +572,9 @@ if (!function_exists('to_name_value')) {
         $data = [];
         foreach ($array as $name => $value) {
             $row = ['name' => $name, 'value' => $value];
-            if (isset($keys)) $row = array_merge($row, $keys);
+            if (isset($keys)) {
+                $row = array_merge($row, $keys);
+            }
             array_push($data, $row);
         }
 
@@ -581,7 +586,9 @@ if (!function_exists('find')) {
     function find($array, $key, $value)
     {
         foreach ($array as $item) {
-            if (isset($item[$key]) && ($item[$key] == $value)) return $item;
+            if (isset($item[$key]) && ($item[$key] == $value)) {
+                return $item;
+            }
         }
     }
 }
@@ -590,7 +597,7 @@ if (!function_exists('is_numeric_array')) {
     // http://stackoverflow.com/questions/902857/php-getting-array-type
     function is_numeric_array($array)
     {
-        return ($array == array_values($array));
+        return $array == array_values($array);
     }
 }
 
@@ -615,7 +622,7 @@ if (!function_exists('debug')) {
 
 if (!function_exists('register_global_hooks')) {
     /**
-     * Register all the hooks from the configuration file
+     * Register all the hooks from the configuration file.
      *
      * @param Application $app
      */
@@ -628,7 +635,7 @@ if (!function_exists('register_global_hooks')) {
 
 if (!function_exists('register_extensions_hooks')) {
     /**
-     * Register all extensions hooks
+     * Register all extensions hooks.
      *
      * @param Application $app
      */
@@ -653,7 +660,7 @@ if (!function_exists('register_extensions_hooks')) {
 
 if (!function_exists('register_webhooks')) {
     /**
-     * Register all the hooks from the directus_webhooks table
+     * Register all the hooks from the directus_webhooks table.
      *
      * @param Application $app
      */
@@ -666,8 +673,8 @@ if (!function_exists('register_webhooks')) {
             $webhookData = $webhook->findAll(['status' => \Directus\Api\Routes\Webhook::STATUS_ACTIVE], false);
             $result = [];
             foreach ($webhookData['data'] as $hook) {
-                $action = explode(":", $hook['directus_action']);
-                $result['hooks']['actions'][$action[0] . "." . $hook['collection'] . ":" . $action[1]] = function ($data) use ($hook) {
+                $action = explode(':', $hook['directus_action']);
+                $result['hooks']['actions'][$action[0].'.'.$hook['collection'].':'.$action[1]] = function ($data) use ($hook) {
                     $client = new \GuzzleHttp\Client();
                     $response = [];
                     if ($hook['http_action'] == WebhookService::HTTP_ACTION_POST) {
@@ -685,10 +692,10 @@ if (!function_exists('register_webhooks')) {
 
 if (!function_exists('register_hooks_list')) {
     /**
-     * Register an array of hooks (containing a list of actions and filters)
+     * Register an array of hooks (containing a list of actions and filters).
      *
      * @param Application $app
-     * @param array $hooksList
+     * @param array       $hooksList
      */
     function register_hooks_list(Application $app, array $hooksList)
     {
@@ -701,11 +708,11 @@ if (!function_exists('register_hooks_list')) {
 
 if (!function_exists('register_hooks')) {
     /**
-     * Load one or multiple listeners
+     * Load one or multiple listeners.
      *
-     * @param Application $app
+     * @param Application    $app
      * @param array|\Closure $listeners
-     * @param bool $areFilters
+     * @param bool           $areFilters
      */
     function register_hooks(Application $app, $listeners, $areFilters = false)
     {
@@ -729,13 +736,13 @@ if (!function_exists('register_hooks')) {
 
 if (!function_exists('register_hook')) {
     /**
-     * Register a hook listeners
+     * Register a hook listeners.
      *
-     * @param Emitter $emitter
-     * @param string $name
+     * @param Emitter  $emitter
+     * @param string   $name
      * @param callable $listener
      * @param int|null $priority
-     * @param bool $areFilters
+     * @param bool     $areFilters
      */
     function register_hook(Emitter $emitter, $name, $listener, $priority = null, $areFilters = false)
     {
@@ -749,10 +756,10 @@ if (!function_exists('register_hook')) {
 
 if (!function_exists('register_action_hook')) {
     /**
-     * Register a hook action
+     * Register a hook action.
      *
-     * @param Emitter $emitter
-     * @param string $name
+     * @param Emitter  $emitter
+     * @param string   $name
      * @param callable $listener
      * @param int|null $priority
      */
@@ -764,12 +771,12 @@ if (!function_exists('register_action_hook')) {
 
 if (!function_exists('register_hook_filter')) {
     /**
-     * Register a hook action
+     * Register a hook action.
      *
      * @param \Directus\Hook\Emitter $emitter
-     * @param string $name
-     * @param callable $listener
-     * @param int|null $priority
+     * @param string                 $name
+     * @param callable               $listener
+     * @param int|null               $priority
      */
     function register_filter_hook(\Directus\Hook\Emitter $emitter, $name, $listener, $priority = null)
     {
@@ -779,7 +786,7 @@ if (!function_exists('register_hook_filter')) {
 
 if (!function_exists('get_default_timezone')) {
     /**
-     * Returns the default timezone
+     * Returns the default timezone.
      *
      * @param Application $app
      *
@@ -831,14 +838,14 @@ if (!function_exists('base_path')) {
     {
         $app = Application::getInstance();
 
-        $path = $app ? $app->getContainer()->get('path_base') : realpath(__DIR__ . '/../../');
+        $path = $app ? $app->getContainer()->get('path_base') : realpath(__DIR__.'/../../');
 
         if (!is_string($suffix)) {
             throw new Exception('suffix must be a string');
         }
 
         if ($suffix) {
-            $path = rtrim($path, '/') . '/' . ltrim($suffix, '/');
+            $path = rtrim($path, '/').'/'.ltrim($suffix, '/');
         }
 
         return $path;
@@ -847,7 +854,7 @@ if (!function_exists('base_path')) {
 
 if (!function_exists('get_fake_timezones')) {
     /**
-     * Gets the list of fake timezone map to an real one
+     * Gets the list of fake timezone map to an real one.
      *
      * @return array
      */
@@ -875,14 +882,14 @@ if (!function_exists('get_fake_timezones')) {
             'Pacific/Marshall_Is' => 'Pacific/Fiji',
             'Asia/Solomon_Is' => 'Asia/Magadan',
             'Asia/New_Caledonia' => 'Asia/Magadan',
-            'Pacific/Wellington' => 'Pacific/Auckland'
+            'Pacific/Wellington' => 'Pacific/Auckland',
         ];
     }
 }
 
 if (!function_exists('get_real_timezone')) {
     /**
-     * Gets the real name of the timezone name
+     * Gets the real name of the timezone name.
      *
      * we have fake it until php makes it
      *
@@ -893,6 +900,7 @@ if (!function_exists('get_real_timezone')) {
     function get_real_timezone($name)
     {
         $fakes = get_fake_timezones();
+
         return isset($fakes[$name]) ? $fakes[$name] : $name;
     }
 }
@@ -1330,7 +1338,7 @@ if (!function_exists('get_country_list')) {
 
 if (!function_exists('find_directories')) {
     /**
-     * Gets directories inside the given path
+     * Gets directories inside the given path.
      *
      * @param $path
      *
@@ -1338,7 +1346,7 @@ if (!function_exists('find_directories')) {
      */
     function find_directories($path)
     {
-        return array_filter(glob(rtrim($path, '/') . '/*', GLOB_ONLYDIR), function ($path) {
+        return array_filter(glob(rtrim($path, '/').'/*', GLOB_ONLYDIR), function ($path) {
             $name = basename($path);
 
             return $name[0] !== '_';
@@ -1351,11 +1359,11 @@ if (!function_exists('find_files')) {
      * Find files inside $paths, directories and file name starting with "_" will be ignored.
      *
      *
-     * @param string $searchPaths
-     * @param int $flags
-     * @param string $pattern
-     * @param bool|int $includeSubDirectories
-     * @param callable - $ignore filter
+     * @param string     $searchPaths
+     * @param int        $flags
+     * @param string     $pattern
+     * @param bool|int   $includeSubDirectories
+     * @param callable - $ignore                filter
      *
      * @return array
      */
@@ -1374,15 +1382,15 @@ if (!function_exists('find_files')) {
         $filesPath = [];
         foreach ($searchPaths as $searchPath) {
             $searchPath = rtrim($searchPath, '/');
-            $result = array_filter(glob($searchPath . '/' . rtrim($pattern, '/'), $flags), $validPath);
+            $result = array_filter(glob($searchPath.'/'.rtrim($pattern, '/'), $flags), $validPath);
             $filesPath = array_merge($filesPath, $result);
 
             if ($includeSubDirectories === true || (int) $includeSubDirectories > 0) {
                 if (is_numeric($includeSubDirectories)) {
-                    $includeSubDirectories--;
+                    --$includeSubDirectories;
                 }
 
-                foreach (glob($searchPath . '/*', GLOB_ONLYDIR) as $subDir) {
+                foreach (glob($searchPath.'/*', GLOB_ONLYDIR) as $subDir) {
                     if ($validPath($subDir)) {
                         $result = find_files($subDir, $flags, $pattern, $includeSubDirectories);
                         $filesPath = array_merge($filesPath, $result);
@@ -1397,9 +1405,9 @@ if (!function_exists('find_files')) {
 
 if (!function_exists('find_js_files')) {
     /**
-     * Find JS files in the given path
+     * Find JS files in the given path.
      *
-     * @param string $paths
+     * @param string   $paths
      * @param bool|int $includeSubDirectories
      *
      * @return array
@@ -1412,9 +1420,9 @@ if (!function_exists('find_js_files')) {
 
 if (!function_exists('find_json_files')) {
     /**
-     * Find JSON files in the given path
+     * Find JSON files in the given path.
      *
-     * @param string $paths
+     * @param string   $paths
      * @param bool|int $includeSubDirectories
      *
      * @return array
@@ -1427,9 +1435,9 @@ if (!function_exists('find_json_files')) {
 
 if (!function_exists('find_log_files')) {
     /**
-     * Find .log files in the given path
+     * Find .log files in the given path.
      *
-     * @param string $paths
+     * @param string   $paths
      * @param bool|int $includeSubDirectories
      *
      * @return array
@@ -1442,9 +1450,9 @@ if (!function_exists('find_log_files')) {
 
 if (!function_exists('find_php_files')) {
     /**
-     * Find PHP files in the given path
+     * Find PHP files in the given path.
      *
-     * @param string $paths
+     * @param string   $paths
      * @param bool|int $includeSubDirectories
      *
      * @return array
@@ -1457,9 +1465,9 @@ if (!function_exists('find_php_files')) {
 
 if (!function_exists('find_html_files')) {
     /**
-     * Find HTML files in the given path
+     * Find HTML files in the given path.
      *
-     * @param string $paths
+     * @param string   $paths
      * @param bool|int $includeSubDirectories
      *
      * @return array
@@ -1472,9 +1480,9 @@ if (!function_exists('find_html_files')) {
 
 if (!function_exists('find_twig_files')) {
     /**
-     * Find Twig files in the given path
+     * Find Twig files in the given path.
      *
-     * @param string $paths
+     * @param string   $paths
      * @param bool|int $includeSubDirectories
      *
      * @return array
@@ -1502,18 +1510,19 @@ if (!function_exists('get_request_host')) {
     function get_request_host()
     {
         /**
-         * Return localhost if the IP is from local env
+         * Return localhost if the IP is from local env.
          *
          * @return string
          */
         $ip = get_request_ip();
-        return in_array($ip, ['127.0.0.1', '::1']) ? "localhost" : $ip;
+
+        return in_array($ip, ['127.0.0.1', '::1']) ? 'localhost' : $ip;
     }
 }
 
 if (!function_exists('get_missing_requirements')) {
     /**
-     * Gets an array of errors message when there's a missing requirements
+     * Gets an array of errors message when there's a missing requirements.
      *
      * @return array
      */
@@ -1545,7 +1554,7 @@ if (!function_exists('get_missing_requirements')) {
             $errors[] = 'Your host needs to have cURL extension enabled to run this version of Directus!';
         }
 
-        if (!file_exists(base_path() . '/vendor/autoload.php')) {
+        if (!file_exists(base_path().'/vendor/autoload.php')) {
             $errors[] = 'Composer dependencies must be installed first.';
         }
 
@@ -1555,9 +1564,9 @@ if (!function_exists('get_missing_requirements')) {
 
 if (!function_exists('display_missing_requirements_html')) {
     /**
-     * Display an html error page
+     * Display an html error page.
      *
-     * @param array $errors
+     * @param array                             $errors
      * @param \Directus\Application\Application $app
      */
     function display_missing_requirements_html($errors, $app)
@@ -1565,7 +1574,7 @@ if (!function_exists('display_missing_requirements_html')) {
         $projectInfo = get_project_info();
 
         $data = array_merge($projectInfo, [
-            'errors' => $errors
+            'errors' => $errors,
         ]);
 
         $app->response()->header('Content-Type', 'text/html; charset=utf-8');
@@ -1575,10 +1584,10 @@ if (!function_exists('display_missing_requirements_html')) {
 
 if (!function_exists('define_constant')) {
     /**
-     * Define a constant if it does not exist
+     * Define a constant if it does not exist.
      *
      * @param string $name
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return bool
      */
@@ -1597,10 +1606,10 @@ if (!function_exists('define_constant')) {
 
 if (!function_exists('get_columns_flat_at')) {
     /**
-     * Get all the columns name in the given level
+     * Get all the columns name in the given level.
      *
      * @param array $columns
-     * @param int $level
+     * @param int   $level
      *
      * @return array
      */
@@ -1622,23 +1631,23 @@ if (!function_exists('get_columns_flat_at')) {
 
 if (!function_exists('get_csv_flat_columns')) {
     /**
-     * Gets a CSV flat columns list from the given array
+     * Gets a CSV flat columns list from the given array.
      *
      * @param array $columns
-     * @param null $prefix
+     * @param null  $prefix
      *
      * @return string
      */
     function get_csv_flat_columns(array $columns, $prefix = null)
     {
         $flatColumns = [];
-        $prefix = $prefix === null ? '' : $prefix . '.';
+        $prefix = $prefix === null ? '' : $prefix.'.';
 
         foreach ($columns as $key => $value) {
             if (is_array($value)) {
-                $value = get_csv_flat_columns($value, $prefix . $key);
+                $value = get_csv_flat_columns($value, $prefix.$key);
             } else {
-                $value = $prefix . $key;
+                $value = $prefix.$key;
             }
 
             $flatColumns[] = $value;
@@ -1650,7 +1659,7 @@ if (!function_exists('get_csv_flat_columns')) {
 
 if (!function_exists('get_array_flat_columns')) {
     /**
-     * Gets an array flat columns list from the given array
+     * Gets an array flat columns list from the given array.
      *
      * @param $columns
      *
@@ -1669,7 +1678,7 @@ if (!function_exists('get_array_flat_columns')) {
 
 if (!function_exists('get_unflat_columns')) {
     /**
-     * Gets the unflat version of flat (dot-notated) column list
+     * Gets the unflat version of flat (dot-notated) column list.
      *
      * @param string|array $columns
      *
@@ -1704,7 +1713,7 @@ if (!function_exists('get_unflat_columns')) {
                     }
 
                     $names[$parts[0]][key($child)] = $childValue;
-                };
+                }
             }
         }
 
@@ -1714,7 +1723,7 @@ if (!function_exists('get_unflat_columns')) {
 
 if (!function_exists('column_identifier_reverse')) {
     /**
-     * Reverse a dot notation column identifier
+     * Reverse a dot notation column identifier.
      *
      * Ex: posts.comments.author.email => email.author.comments.posts
      *
@@ -1736,7 +1745,7 @@ if (!function_exists('column_identifier_reverse')) {
 
 if (!function_exists('compact_sort_to_array')) {
     /**
-     * Converts compact sorting column to array
+     * Converts compact sorting column to array.
      *
      * Example: -<field> to [field => 'DESC']
      *
@@ -1759,7 +1768,7 @@ if (!function_exists('compact_sort_to_array')) {
         }
 
         return [
-            $field => $order
+            $field => $order,
         ];
     }
 }
@@ -1784,7 +1793,7 @@ if (!function_exists('convert_param_columns')) {
 
 if (!function_exists('is_valid_regex_pattern')) {
     /**
-     * Checks whether the given pattern is a valid regex
+     * Checks whether the given pattern is a valid regex.
      *
      * @param string $pattern
      *
@@ -1804,7 +1813,7 @@ if (!function_exists('is_valid_regex_pattern')) {
 
 if (!function_exists('is_custom_validation')) {
     /**
-     * Checks whether the given value is a custom validation
+     * Checks whether the given value is a custom validation.
      *
      * @param string $value
      *
@@ -1820,7 +1829,7 @@ if (!function_exists('is_custom_validation')) {
 
 if (!function_exists('get_custom_validation_name')) {
     /**
-     * Returns the custom validation constraint name
+     * Returns the custom validation constraint name.
      *
      * @param string $value
      *
@@ -1834,12 +1843,12 @@ if (!function_exists('get_custom_validation_name')) {
 
 if (!function_exists('env')) {
     /**
-     * Returns an environment variable
+     * Returns an environment variable.
      *
      * @param string $key
-     * @param null $default
+     * @param null   $default
      *
-     * @return array|false|null|string
+     * @return array|false|string|null
      */
     function env($key, $default = null)
     {
@@ -1856,9 +1865,9 @@ if (!function_exists('env')) {
 if (!function_exists('phinx_update')) {
     /**
      * @param AdapterInterface $adapter
-     * @param string $table
-     * @param array $data
-     * @param array $conditions
+     * @param string           $table
+     * @param array            $data
+     * @param array            $conditions
      *
      * @return string
      */
@@ -1886,7 +1895,7 @@ if (!function_exists('phinx_update')) {
 
 if (!function_exists('is_valid_datetime')) {
     /**
-     * Checks if the given datetime string has the given datetime format
+     * Checks if the given datetime string has the given datetime format.
      *
      * @param string $value
      * @param string $format
@@ -1903,7 +1912,7 @@ if (!function_exists('is_valid_datetime')) {
 
 if (!function_exists('is_iso8601_datetime')) {
     /**
-     * Checks if the given datetime string is a ISO 8601 datetime format
+     * Checks if the given datetime string is a ISO 8601 datetime format.
      *
      * @param string $value
      *
@@ -1920,7 +1929,7 @@ if (!function_exists('is_iso8601_datetime')) {
 
 if (!function_exists('is_iso8601_format_one')) {
     /**
-     * Checks whether the given string is a iso format (1)
+     * Checks whether the given string is a iso format (1).
      *
      * Format: 2019-01-04T16:12:05+00:00
      *
@@ -1941,7 +1950,7 @@ if (!function_exists('is_iso8601_format_one')) {
 
 if (!function_exists('is_iso8601_format_two')) {
     /**
-     * Checks whether the given string is a iso format (2)
+     * Checks whether the given string is a iso format (2).
      *
      * Format: 2019-01-04T16:12:05Z
      *
@@ -1962,7 +1971,7 @@ if (!function_exists('is_iso8601_format_two')) {
 
 if (!function_exists('is_iso8601_format_three')) {
     /**
-     * Checks whether the given string is a iso format (3)
+     * Checks whether the given string is a iso format (3).
      *
      * Format: 20190104T161205Z
      *
@@ -1983,7 +1992,7 @@ if (!function_exists('is_iso8601_format_three')) {
 
 if (!function_exists('is_iso8601_format_four')) {
     /**
-     * Checks whether the given string is a iso format (4)
+     * Checks whether the given string is a iso format (4).
      *
      * Format: 2019-02-06T10:53:31-0500
      *
@@ -2004,11 +2013,11 @@ if (!function_exists('is_iso8601_format_four')) {
 
 if (!function_exists('get_iso8601_format')) {
     /**
-     * Returns the iso format based on the datetime value
+     * Returns the iso format based on the datetime value.
      *
      * @param string $value
      *
-     * @return null|string
+     * @return string|null
      */
     function get_iso8601_format($value)
     {
@@ -2020,11 +2029,11 @@ if (!function_exists('get_iso8601_format')) {
 
         if (is_iso8601_format_one($value)) {
             $format = DateTimeUtils::ISO8601_FORMAT_ONE;
-        } else if (is_iso8601_format_two($value)) {
+        } elseif (is_iso8601_format_two($value)) {
             $format = DateTimeUtils::ISO8601_FORMAT_TWO;
-        } else if (is_iso8601_format_three($value)) {
+        } elseif (is_iso8601_format_three($value)) {
             $format = DateTimeUtils::ISO8601_FORMAT_THREE;
-        } else if (is_iso8601_format_four($value)) {
+        } elseif (is_iso8601_format_four($value)) {
             $format = DateTimeUtils::ISO8601;
         }
 
@@ -2045,7 +2054,7 @@ if (!function_exists('normalize_exception')) {
         }
 
         $stack = [
-            sprintf("%s: %s in %s:%d\nStack trace:", get_class($e), $e->getMessage(), $e->getFile(), $e->getLine())
+            sprintf("%s: %s in %s:%d\nStack trace:", get_class($e), $e->getMessage(), $e->getFile(), $e->getLine()),
         ];
 
         // format: stack index - filename - line - call
@@ -2055,7 +2064,7 @@ if (!function_exists('normalize_exception')) {
             $line = isset($trace['line']) ? sprintf('(%s)', $trace['line']) : '';
 
             if (isset($trace['class'])) {
-                $call = $trace['class'] . $trace['type'] . $trace['function'];
+                $call = $trace['class'].$trace['type'].$trace['function'];
             } else {
                 $call = $trace['function'];
             }
@@ -2075,7 +2084,7 @@ if (!function_exists('normalize_exception')) {
 
 if (!function_exists('is_empty')) {
     /**
-     * Checks whether or not the value is empty|null
+     * Checks whether or not the value is empty|null.
      *
      * @param mixed $value
      *


### PR DESCRIPTION
It seems that some setups forces Authorization header to be present in PHP `$_SERVER`, which was causing an invalid validation on our token extraction method.

This makes it fallback to other methods if Authorization contains an empty value.

Fixes OP's case in https://github.com/directus/directus/issues/2510
