### PR TITLE
Fix #1644 [Use TEXT for module_listing / collection_listing]

### DIFF
--- a/migrations/upgrades/20200120170859_update_type_of_collection_listing.php
+++ b/migrations/upgrades/20200120170859_update_type_of_collection_listing.php
@@ -4,37 +4,12 @@ use Phinx\Migration\AbstractMigration;
 
 class UpdateTypeOfCollectionListing extends AbstractMigration
 {
-    /**
-     * Change Method.
-     *
-     * Write your reversible migrations using this method.
-     *
-     * More information on writing migrations is available here:
-     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
-     *
-     * The following commands can be used in this method and Phinx will
-     * automatically reverse them when rolling back:
-     *
-     *    createTable
-     *    renameTable
-     *    addColumn
-     *    addCustomColumn
-     *    renameColumn
-     *    addIndex
-     *    addForeignKey
-     *
-     * Any other destructive changes will result in an error when trying to
-     * rollback the migration.
-     *
-     * Remember to call "create()" or "update()" and NOT "save()" when working
-     * with the Table class.
-     */
     public function change()
     {
         $rolesTable = $this->table('directus_roles');
 
         // -------------------------------------------------------------------------
-        // Add collection_listing column
+        // Update collection_listing column
         // -------------------------------------------------------------------------
         if ($rolesTable->hasColumn('collection_listing')) {
             $rolesTable->changeColumn('collection_listing', 'text', [

--- a/migrations/upgrades/20200120170859_update_type_of_collection_listing.php
+++ b/migrations/upgrades/20200120170859_update_type_of_collection_listing.php
@@ -16,5 +16,14 @@ class UpdateTypeOfCollectionListing extends AbstractMigration
                 'null' => true
             ])->update();
         }
+
+        // -------------------------------------------------------------------------
+        // Update module_listing column
+        // -------------------------------------------------------------------------
+        if ($rolesTable->hasColumn('module_listing')) {
+            $rolesTable->changeColumn('module_listing', 'text', [
+                'null' => true
+            ])->update();
+        }
     }
 }

--- a/migrations/upgrades/20200120170859_update_type_of_collection_listing.php
+++ b/migrations/upgrades/20200120170859_update_type_of_collection_listing.php
@@ -1,0 +1,45 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class UpdateTypeOfCollectionListing extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+     *
+     * The following commands can be used in this method and Phinx will
+     * automatically reverse them when rolling back:
+     *
+     *    createTable
+     *    renameTable
+     *    addColumn
+     *    addCustomColumn
+     *    renameColumn
+     *    addIndex
+     *    addForeignKey
+     *
+     * Any other destructive changes will result in an error when trying to
+     * rollback the migration.
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change()
+    {
+        $rolesTable = $this->table('directus_roles');
+
+        // -------------------------------------------------------------------------
+        // Add collection_listing column
+        // -------------------------------------------------------------------------
+        if ($rolesTable->hasColumn('collection_listing')) {
+            $rolesTable->changeColumn('collection_listing', 'text', [
+                'null' => true
+            ])->update();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1662, #1644

`Installation` has already `text` type. Just need to update if for `Upgrades`