### PR TITLE
fix #1722

### DIFF
--- a/src/core/Directus/Database/Schema/SchemaManager.php
+++ b/src/core/Directus/Database/Schema/SchemaManager.php
@@ -75,6 +75,19 @@ class SchemaManager
         'users'
     ];
 
+     /**
+     * Data types that don't require length. See https://dev.mysql.com/doc/refman/8.0/en/string-type-syntax.html
+     * @var array
+     */
+    protected $noLengthDataTypes = [        
+        'TINYTEXT',
+        'MEDIUMTEXT',
+        'LONGTEXT',
+        'TINYBLOB',
+        'MEDIUMBLOB',
+        'LONGBLOB'
+    ];
+
     public function __construct(SchemaInterface $source)
     {
         $this->source = $source;
@@ -556,12 +569,14 @@ class SchemaManager
         // NOTE: Alias column must are nullable
         if (DataTypes::isAliasType($fieldType)) {
             $column['nullable'] = true;
-        }
-
+        }        
+                
         if ($this->isFloatingPointType($dataType)) {
             $column['length'] = sprintf('%d,%d', $column['precision'], $column['scale']);
         } else if ($this->source->isIntegerType($dataType)) {
             $column['length'] = $column['precision'];
+        } else if (in_array($dataType, $this->noLengthDataTypes)) {
+            $column['length'] = null;        
         } else {
             $column['length'] = $column['char_length'];
         }


### PR DESCRIPTION
set length = null for datatypes that don't allow null like LONGTEXT and MEDIUMTEXT

Fixes #1722