### PR TITLE
Fix O2M, M2O, and M2M relations in GraphQL queries

### DIFF
--- a/src/core/Directus/GraphQL/FieldsConfig.php
+++ b/src/core/Directus/GraphQL/FieldsConfig.php
@@ -50,9 +50,19 @@ class FieldsConfig
                     $fields[$v['field']] = Types::directusFile();
                     break;
                 case 'integer':
-                    $fields[$v['field']] = Types::int();
-                    if ($v['primary_key']) {
+                    // Check if this field is actually part of an M2O relation
+                    $other = $this->getOtherCollectionManyToOne(
+                        $v['collection'], $v['field']);
+                    if (!is_null($other)) {
+                        // This field is part of an M2O, pointing to collection
+                        // $other
+                        $fields[$v['field']] = Types::userCollection($other);
+                    } else if ($v['interface'] == 'primary-key') {
+                        // This is the primary key of the table
                         $fields[$v['field']] = Types::id();
+                    } else {
+                        // This is just a plain integer
+                        $fields[$v['field']] = Types::int();
                     }
                     break;
                 case 'decimal':
@@ -62,21 +72,16 @@ class FieldsConfig
                     $fields[$v['field']] = Types::json();
                     break;
                 case 'm2o':
-                    $relation = $this->getRelation('m2o', $v['collection'], $v['field']);
-                    $fields[$v['field']] = Types::userCollection($relation['collection_one']);
+                    $collection = $this->getOtherCollectionManyToOne(
+                        $v['collection'], $v['field']);
+                    $fields[$v['field']] = Types::userCollection($collection);
                     break;
                 case 'o2m':
-                    $relation = $this->getRelation('o2m', $v['collection'], $v['field']);
-                    $temp = [];
-                    $temp['type'] = Types::listOf(Types::userCollection($relation['collection_one']));
-                    $temp['resolve'] = function ($value, $args, $context, $info) use ($relation) {
-                        $data = [];
-                        foreach ($value[$info->fieldName] as  $v) {
-                            $data[] = $v[$relation['field_many']];
-                        }
-                        return $data;
-                    };
-                    $fields[$v['field']] = $temp;
+                case 'translation': // translation is just an o2m collection
+                    $collection = $this->getOtherCollectionOneToMany(
+                        $v['collection'], $v['field']);
+                    $fields[$v['field']] = Types::listOf(
+                        Types::userCollection($collection));
                     break;
                 case 'sort':
                     $fields[$v['field']] = Types::int();
@@ -86,10 +91,6 @@ class FieldsConfig
                     break;
                 case 'time':
                     $fields[$v['field']] = Types::time();
-                    break;
-                case 'translation':
-                    $relation = $this->getRelation('translation', $v['collection'], $v['field']);
-                    $fields[$v['field']] = Types::listOf(Types::userCollection($relation['collection_many']));
                     break;
                 case 'owner':
                 case 'user_updated':
@@ -199,60 +200,57 @@ class FieldsConfig
         return $filters;
     }
 
-    private function getRelation($type, $collection, $field)
+   /**
+     * Given collection and a field on the same collection, which is assumed
+     * to be an one to many relation, returns the name of the other (many)
+     * collection.
+     *
+     * @param string $collection The name of the collection
+     * @param string $field The name of the field
+     * @return string The name of the other (many) collection
+     */
+    private function getOtherCollectionOneToMany($collection, $field)
     {
-        //List all the relation
         $relationsService = new RelationsService($this->container);
-        $relationsData = $relationsService->findAll();
-        $relation = [];
-        switch ($type) {
-            case 'm2o':
-                foreach ($relationsData['data'] as $k => $v) {
-                    if ($v['collection_many'] == $collection && $v['field_many'] == $field) {
-                        $relation = $v;
-                        break;
-                    }
-                }
-                break;
-            case 'o2m':
-                /**
-                 * TODO :: Need to rewrite the code for better readiablity.
-                 */
-                $firstRelation;
+        $relationsData = $relationsService->findAll([
+            'filter' => [
+                'collection_one' => $collection,
+                'field_one' => $field
+            ]
+        ])['data'];
 
-                //1. Find the collection_many
-                foreach ($relationsData['data'] as $k => $v) {
-                    if ($v['collection_one'] == $collection && $v['field_one'] == $field) {
-                        $firstRelation = $v;
-                        break;
-                    }
-                }
-                $collectionMany = $firstRelation['collection_many'];
-                $collection1Id = $firstRelation['id'];
-
-                //2. Find the 2nd collection_one
-                foreach ($relationsData['data'] as $k => $v) {
-                    if ($v['collection_many'] == $collectionMany && $v['id'] != $collection1Id) {
-                        $relation = $v;
-                        break;
-                    }
-                }
-
-                if (count($relation) == 0) {
-                    $relation = $firstRelation;
-                }
-
-                break;
-            case 'translation':
-                foreach ($relationsData['data'] as $k => $v) {
-                    if ($v['collection_one'] == $collection && $v['field_one'] == $field) {
-                        $relation = $v;
-                        break;
-                    }
-                }
-                break;
+        foreach ($relationsData as $v) {
+            if ($v) {
+                return $v['collection_many'];
+            }
         }
 
-        return $relation;
+        return null;
+    }
+
+    /**
+     * Given collection and a field on the same collection, which is assumed
+     * to be a many to one relation, returns the name of the other (one)
+     * collection.
+     *
+     * @param string $collection The name of the collection
+     * @param string $field The name of the field
+     * @return string The name of the other (one) collection
+     */
+    private function getOtherCollectionManyToOne($collection, $field)
+    {
+        $relationsService = new RelationsService($this->container);
+        $relationsData = $relationsService->findAll([
+            'filter' => [
+                'collection_many' => $collection,
+                'field_many' => $field
+            ]
+        ])['data'];
+
+        foreach ($relationsData as $v) {
+            if ($v) { return $v['collection_one']; }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Alright, the other PR (https://github.com/directus/api/pull/1481) got messed up a bit with the history, so I though it would be best to keep things clean.

Pasting its description below.

> Reimplemented O2M and M2O relations. Changed translations to be treated as O2M relations. Added a special case check for integers to see if they represent M2O relations, private keys, or plain integers.
> 
> Tested O2M, M2O, and M2M. Tested M2M relations with two or more junction tables between the same two collections.
> 
> Does NOT address #1401.

Fixes #1412, fixes #1167, fixes #1394.