### PR TITLE
Fixed config file creation validation

### DIFF
--- a/src/core/Directus/Util/Installation/InstallerUtils.php
+++ b/src/core/Directus/Util/Installation/InstallerUtils.php
@@ -470,7 +470,7 @@ class InstallerUtils
         $input = ArrayUtils::omit($data, ['private']);
         $configPath = static::createConfigPathFromData($path, $input);
 
-        static::ensureDirectoryIsWritable($path);
+        static::ensureDirectoryIsWritable($path . '/config');
         if ($force !== true) {
             static::ensureFileDoesNotExists($configPath);
         }


### PR DESCRIPTION
Moving PR from `directus/directus` project: https://github.com/directus/directus/pull/2580

`InstallerUtils::ensureCanCreateConfig` was checking if `/var/directus` is writable instead of `/var/directus/config`.