### PR TITLE
Fix #1542: Use file streaming instead of reading to memory

### DIFF
--- a/src/core/Directus/Filesystem/Files.php
+++ b/src/core/Directus/Filesystem/Files.php
@@ -2,13 +2,12 @@
 
 namespace Directus\Filesystem;
 
-use Char0n\FFMpegPHP\Movie;
 use Directus\Application\Application;
+use Slim\Http\UploadedFile;
 use function Directus\filename_put_ext;
 use function Directus\generate_uuid4;
 use function Directus\is_a_url;
 use Directus\Util\ArrayUtils;
-use Directus\Util\DateTimeUtils;
 use Directus\Util\Formatting;
 use Directus\Util\MimeTypeUtils;
 
@@ -78,6 +77,7 @@ class Files
             $this->emitter->run('file.delete:after', [$file]);
         }
     }
+
     public function deleteThumb($file)
     {
         $ignoreableFiles = ['.DS_Store', '..', '.'];
@@ -89,38 +89,6 @@ class Files
                 $this->filesystem->getAdapter()->delete($fileName);
             }
         }
-    }
-
-    /**
-     * Copy $_FILES data into directus media
-     *
-     * @param array $file $_FILES data
-     *
-     * @return array directus file info data
-     */
-    public function upload(array $file)
-    {
-        $filePath = $file['tmp_name'];
-        $fileName = $file['name'];
-
-        $fileData = array_merge($this->defaults, $this->processUpload($filePath, $fileName));
-
-        return [
-            'type' => $fileData['type'],
-            'name' => $fileData['name'],
-            'title' => $fileData['title'],
-            'tags' => $fileData['tags'],
-            'description' => $fileData['caption'],
-            'location' => $fileData['location'],
-            'charset' => $fileData['charset'],
-            'size' => $fileData['size'],
-            'width' => $fileData['width'],
-            'height' => $fileData['height'],
-            //    @TODO: Returns date in ISO 8601 Ex: 2016-06-06T17:18:20Z
-            //    see: https://en.wikipedia.org/wiki/ISO_8601
-            'date_uploaded' => $fileData['date_uploaded'], // . ' UTC',
-            'storage' => $fileData['storage']
-        ];
     }
 
     /**
@@ -278,7 +246,7 @@ class Files
     /**
      * Copy base64 data into Directus Media
      *
-     * @param string $fileData - base64 data or directus_files object
+     * @param string|UploadedFile $fileData - base64 data or directus_files object
      * @param string $fileName - name of the file
      * @param bool $replace
      *
@@ -303,31 +271,39 @@ class Files
             $checksum = md5($fileData);
             $size = strlen($fileData);
         }
-        // @TODO: merge with upload()
+
         $fileName = $this->getFileName($fileName, $replace !== true);
         $filePath = $this->getConfig('root') . '/' . $fileName;
-        $ext = pathinfo($fileName, PATHINFO_EXTENSION);
+
         $event = $replace ? 'file.update' : 'file.save';
         $this->emitter->run($event, ['name' => $fileName, 'size' => $size]);
 
         // On name change, the file would be overwritten with the empty file data.
         // This prevents you can't update a file to a zero-byte file.
         if (!empty($fileData)) {
+            // This is where the actual bytes of the file are actually written to storage,
+            // which may be the local filesystem or remote.
             $this->write($fileName, $fileData, $replace);
         }
 
         $this->emitter->run($event . ':after', ['name' => $fileName, 'size' => $size]);
 
         #open local tmp file since s3 bucket is private
-        if (isset($fileData->file)) {
-            $handle = fopen($fileData->file, 'rb');
-            $tmp = tempnam(sys_get_temp_dir(), $fileName);
-            file_put_contents($tmp, $handle);
+        // Changed to use the existing temporary uploaded file on disk. As far as I can tell,
+        // this method is only ever called from FilesServices::create and ::update (via
+        // FilesServices::getSaveData) and $fileData will only ever be an object with a
+        // "file" property if it's an UploadedFile, so "file" is always already the path to
+        // a temporary file on disk.
+        $tmp = null;
+        if (is_object($fileData) && isset($fileData->file)) {
+            // Keep track of the local temporary uploaded file so we can extract extra
+            // metadata from it later, if possible.
+            $tmp = $fileData->file;
         }
 
         unset($fileData);
 
-        $fileData = $this->getFileInfo($fileName);
+        $fileData = $this->getFileInfo($fileName, false, $tmp);
         $fileData['title'] = Formatting::fileNameToFileTitle($title);
         $fileData['filename_disk'] = basename($filePath);
         $fileData['storage'] = $this->config['adapter'];
@@ -335,24 +311,28 @@ class Files
         $fileData = array_merge($this->defaults, $fileData);
 
         # Updates for file meta data tags
-        if (strpos($fileData['type'], 'video') !== false) {
+        // Only try to extract extra metadata if we know we have a local copy on the filesystem.
+        // @TODO This should probably be moved to the appropriate getFileInfo methods
+        if (isset($tmp) && strpos($fileData['type'], 'video') !== false) {
             #use ffprobe on local file, can't stream data to it or reference
             $output = shell_exec("ffprobe {$tmp} -show_entries format=duration:stream=height,width -v quiet -of json");
             #echo($output);
             $media = json_decode($output);
-            $width = $media->streams[0]->width;
-            $height = $media->streams[0]->height;
-            $duration = $media->format->duration;   #seconds
+            if (is_object($media) && count($media->streams)) {
+                $width = $media->streams[0]->width;
+                $height = $media->streams[0]->height;
+                if (is_object($media->format) && isset($media->format->duration)) {
+                    $duration = $media->format->duration;   #seconds
+                }
+            }
 
-        } elseif (strpos($fileData['type'], 'audio') !== false) {
+        } elseif (isset($tmp) && strpos($fileData['type'], 'audio') !== false) {
             $output = shell_exec("ffprobe {$tmp} -show_entries format=duration -v quiet -of json");
             $media = json_decode($output);
-            $duration = $media->format->duration;
+            if (is_object($media) && is_object($media->format) && isset($media->format->duration)) {
+                $duration = $media->format->duration;
+            }
         }
-        if (isset($handle)) {
-            fclose($handle);
-        }
-        unset($tmpData);
 
         $response = [
             // The MIME type will be based on its extension, rather than its extension
@@ -406,13 +386,19 @@ class Files
      *
      * @param string $path - file path
      * @param bool $outside - if the $path is outside of the adapter root path.
+     * @param string|null $localCopy - path to local copy of the file, if available
      *
      * @throws \RuntimeException
      *
      * @return array file information
      */
-    public function getFileInfo($path, $outside = false)
+    public function getFileInfo($path, $outside = false, $localCopy = null)
     {
+        if (!is_null($localCopy)) {
+            // If there is a local copy, we can collect all the metadata we need without
+            // loading the data into memory.
+            return $this->getFileInfoFromLocalCopy($path, $localCopy);
+        }
         if ($outside === true) {
             $buffer = file_get_contents($path);
             $fileData = $this->getFileInfoFromData($buffer);
@@ -423,9 +409,46 @@ class Files
         return $fileData;
     }
 
+    /**
+     * Collect metadata about a file for which there exists a local copy on disk
+     *
+     * @param string $path
+     * @param string $localCopy
+     * @return array
+     */
+    public function getFileInfoFromLocalCopy($path, $localCopy)
+    {
+        $mime = MimeTypeUtils::getFromFilename($path);
+
+        $typeTokens = explode('/', $mime);
+
+        $size = filesize($localCopy);
+        $info = [
+            'type' => $mime,
+            'format' => $typeTokens[1],
+            'size' => $size,
+            'width' => null,
+            'height' => null
+        ];
+
+        if ($typeTokens[0] == 'image') {
+            $meta = [];
+            $imageInfo = getimagesize($localCopy, $meta);
+            $this->collectImageInfo($imageInfo, $meta, $info);
+        }
+
+        return $info;
+    }
+
+    /**
+     * Collect metadata about a file in storage
+     *
+     * @param string $path
+     * @return array
+     * @throws \League\Flysystem\FileNotFoundException
+     */
     public function getFileInfoFromPath($path)
     {
-
         $mime = $this->filesystem->getAdapter()->getMimetype($path);
 
         $typeTokens = explode('/', $mime);
@@ -447,6 +470,12 @@ class Files
         return $info;
     }
 
+    /**
+     * Extract metadata from file contents
+     *
+     * @param string $data
+     * @return array
+     */
     public function getFileInfoFromData($data)
     {
         if (!class_exists('\finfo')) {
@@ -473,45 +502,55 @@ class Files
             $meta = [];
             // @TODO: use this as fallback for finfo?
             $imageInfo = getimagesizefromstring($data, $meta);
-
-            $info['width'] = $imageInfo[0];
-            $info['height'] = $imageInfo[1];
-
-            if (isset($meta['APP13'])) {
-                $iptc = iptcparse($meta['APP13']);
-
-                if (isset($iptc['2#120'])) {
-                    $info['caption'] = $iptc['2#120'][0];
-                }
-
-                if (isset($iptc['2#005']) && $iptc['2#005'][0] != '') {
-                    $info['title'] = $iptc['2#005'][0];
-                }
-
-                if (isset($iptc['2#025'])) {
-                    $info['tags'] = implode(',', $iptc['2#025']);
-                }
-
-                $location = [];
-                if (isset($iptc['2#090']) && $iptc['2#090'][0] != '') {
-                    $location[] = $iptc['2#090'][0];
-                }
-
-                if (isset($iptc['2#095'][0]) && $iptc['2#095'][0] != '') {
-                    $location[] = $iptc['2#095'][0];
-                }
-
-                if (isset($iptc['2#101']) && $iptc['2#101'][0] != '') {
-                    $location[] = $iptc['2#101'][0];
-                }
-
-                $info['location'] = implode(', ', $location);
-            }
+            $this->collectImageInfo($imageInfo, $meta, $info);
         }
 
-        unset($data);
-
         return $info;
+    }
+
+    /**
+     * Combine info from getimagesize[fromstring] with existing info array
+     *
+     * @param array|false $imageInfo As returned by getimagesize[fromstring]
+     * @param array $meta As provided via the second argument to getimagesize[fromstring]
+     * @param array $info Passed by reference
+     */
+    protected function collectImageInfo($imageInfo, $meta, &$info)
+    {
+        if (is_array($imageInfo)) {
+            $info['width'] = $imageInfo[0];
+            $info['height'] = $imageInfo[1];
+        }
+        if (is_array($meta) && isset($meta['APP13'])) {
+            $iptc = iptcparse($meta['APP13']);
+
+            if (isset($iptc['2#120'])) {
+                $info['caption'] = $iptc['2#120'][0];
+            }
+
+            if (isset($iptc['2#005']) && $iptc['2#005'][0] != '') {
+                $info['title'] = $iptc['2#005'][0];
+            }
+
+            if (isset($iptc['2#025'])) {
+                $info['tags'] = implode(',', $iptc['2#025']);
+            }
+
+            $location = [];
+            if (isset($iptc['2#090']) && $iptc['2#090'][0] != '') {
+                $location[] = $iptc['2#090'][0];
+            }
+
+            if (isset($iptc['2#095'][0]) && $iptc['2#095'][0] != '') {
+                $location[] = $iptc['2#095'][0];
+            }
+
+            if (isset($iptc['2#101']) && $iptc['2#101'][0] != '') {
+                $location[] = $iptc['2#101'][0];
+            }
+
+            $info['location'] = implode(', ', $location);
+        }
     }
 
     /**
@@ -580,38 +619,6 @@ class Files
         } catch (\Exception $e) {
             throw $e;
         }
-    }
-
-    /**
-     * Creates a new file for Directus Media
-     *
-     * @param string $filePath
-     * @param string $targetName
-     *
-     * @return array file info
-     */
-    private function processUpload($filePath, $targetName)
-    {
-        // set true as $filePath it's outside adapter path
-        // $filePath is on a temporary php directory
-        $fileData = $this->getFileInfo($filePath, true);
-        $mediaPath = $this->filesystem->getPath();
-
-        $fileData['title'] = Formatting::fileNameToFileTitle($targetName);
-
-        $targetName = $this->getFileName($targetName);
-        $finalPath = rtrim($mediaPath, '/') . '/' . $targetName;
-        $data = file_get_contents($filePath);
-
-        $this->emitter->run('file.save', ['name' => $targetName, 'size' => strlen($data)]);
-        $this->write($targetName, $data);
-        $this->emitter->run('file.save:after', ['name' => $targetName, 'size' => strlen($data)]);
-
-        $fileData['name'] = basename($finalPath);
-        $fileData['date_uploaded'] = DateTimeUtils::nowInUTC()->toString();
-        $fileData['storage'] = $this->config['adapter'];
-
-        return $fileData;
     }
 
     /**
@@ -728,27 +735,9 @@ class Files
     }
 
     /**
-     * Get string between two string
-     *
-     * @param string $string
-     * @param string $start
-     * @param string $end
-     *
-     * @return string
-     */
-    private function get_string_between($string, $start, $end)
-    {
-        $string = ' ' . $string;
-        $ini = strpos($string, $start);
-        if ($ini == 0) return '';
-        $ini += strlen($start);
-        $len = strpos($string, $end, $ini) - $ini;
-        return substr($string, $ini, $len);
-    }
-    /**
      * Get a file size and type info from base64 data , URL ,multipart form data
      *
-     * @param string $data
+     * @param string|UploadedFile $data
      *
      * @return array file size and type
      */

--- a/src/core/Directus/Filesystem/Files.php
+++ b/src/core/Directus/Filesystem/Files.php
@@ -523,11 +523,12 @@ class Files
             $info['width'] = $imageInfo[0];
             $info['height'] = $imageInfo[1];
         }
+
         if (is_array($meta) && isset($meta['APP13'])) {
             $iptc = iptcparse($meta['APP13']);
 
             if (isset($iptc['2#120'])) {
-                $info['caption'] = $iptc['2#120'][0];
+                $info['description'] = $iptc['2#120'][0];
             }
 
             if (isset($iptc['2#005']) && $iptc['2#005'][0] != '') {
@@ -539,6 +540,7 @@ class Files
             }
 
             $location = [];
+
             if (isset($iptc['2#090']) && $iptc['2#090'][0] != '') {
                 $location[] = $iptc['2#090'][0];
             }
@@ -553,6 +555,8 @@ class Files
 
             $info['location'] = implode(', ', $location);
         }
+
+        return $info;
     }
 
     /**

--- a/src/core/Directus/Filesystem/Filesystem.php
+++ b/src/core/Directus/Filesystem/Filesystem.php
@@ -44,6 +44,18 @@ class Filesystem
     }
 
     /**
+     * Returns a readable stream for the given location
+     *
+     * @param string $location
+     * @return false|resource
+     * @throws \League\Flysystem\FileNotFoundException
+     */
+    public function readStream($location)
+    {
+        return $this->adapter->readStream($location);
+    }
+
+    /**
      * Writes data to th given location
      *
      * @param string $location

--- a/src/core/Directus/Filesystem/Filesystem.php
+++ b/src/core/Directus/Filesystem/Filesystem.php
@@ -4,6 +4,7 @@ namespace Directus\Filesystem;
 
 use Directus\Filesystem\Exception\ForbiddenException;
 use League\Flysystem\FilesystemInterface as FlysystemInterface;
+use Slim\Http\UploadedFile;
 
 class Filesystem
 {
@@ -56,10 +57,10 @@ class Filesystem
     }
 
     /**
-     * Writes data to th given location
+     * Writes data to the given location
      *
      * @param string $location
-     * @param $data
+     * @param string|UploadedFile $data
      * @param bool $replace
      */
     public function write($location, $data, $replace = false)
@@ -109,6 +110,7 @@ class Filesystem
      */
     public function getPath($path = '')
     {
+        /** @var \League\Flysystem\AdapterInterface $adapter */
         $adapter = $this->adapter->getAdapter();
 
         if ($path) {

--- a/src/core/Directus/Services/AssetService.php
+++ b/src/core/Directus/Services/AssetService.php
@@ -68,7 +68,18 @@ class AssetService extends AbstractService
         $this->thumbnailParams = [];
     }
 
-    public function getAsset($fileHashId, array $params = [])
+    /**
+     * Returns content (string or stream) and metadata for an asset
+     *
+     * @param string $fileHashId
+     * @param array $params
+     * @param bool $asStream
+     * @return array
+     * @throws ItemNotFoundException
+     * @throws UnprocessableEntityException
+     * @throws \League\Flysystem\FileNotFoundException
+     */
+    public function getAsset($fileHashId, array $params = [], $asStream = false)
     {
         $tableGateway = $this->createTableGateway($this->collection);
 
@@ -92,7 +103,11 @@ class AssetService extends AbstractService
             $lastModified = $this->filesystem->getAdapter()->getTimestamp($file['filename_disk']);
             $lastModified = new DateTimeUtils(date('c', $lastModified));
 
-            $img = $this->filesystem->read($file['filename_disk']);
+            if ($asStream === false) {
+                $img = $this->filesystem->read($file['filename_disk']);
+            } else {
+                $img = $this->filesystem->readStream($file['filename_disk']);
+            }
             $result = [];
             $result['last_modified'] = $lastModified->toRFC2616Format();
             $result['mimeType'] = $file['type'];
@@ -106,14 +121,22 @@ class AssetService extends AbstractService
             $this->fileName = $file['filename_disk'];
             $this->fileNameDownload = $file['filename_download'];
             try {
-                return $this->getThumbnail($params);
+                return $this->getThumbnail($params, $asStream);
             } catch (Exception $e) {
                 throw new UnprocessableEntityException(sprintf($e->getMessage()));
             }
         }
     }
 
-    public function getThumbnail($params)
+    /**
+     * Resizes an image and returns content (string or stream) and metadata
+     *
+     * @param array $params
+     * @param bool $asStream
+     * @return mixed
+     * @throws Exception
+     */
+    public function getThumbnail($params, $asStream = false)
     {
         $this->thumbnailParams = $params;
 
@@ -127,16 +150,16 @@ class AssetService extends AbstractService
             ',f' . $this->thumbnailParams['fit'] . ',q' . $this->thumbnailParams['quality'];
 
         try {
-            $image = $this->getExistingThumbnail();
+            $image = $this->getExistingThumbnail($asStream);
 
             if (!$image) {
                 switch ($this->thumbnailParams['fit']) {
                     case 'contain':
-                        $image = $this->contain();
+                        $image = $this->contain($asStream);
                         break;
                     case 'crop':
                     default:
-                        $image = $this->crop();
+                        $image = $this->crop($asStream);
                 }
             }
 
@@ -305,14 +328,20 @@ class AssetService extends AbstractService
     /**
      * Return thumbnail as data
      *
+     * @param boolean $asStream
      * @throws Exception
      * @return string|null
      */
-    public function getExistingThumbnail()
+    public function getExistingThumbnail($asStream = false)
     {
         try {
-            if ($this->filesystemThumb->exists($this->thumbnailDir . '/' . $this->thumbnailParams['thumbnailFileName'])) {
-                $img = $this->filesystemThumb->read($this->thumbnailDir . '/' . $this->thumbnailParams['thumbnailFileName']);
+            $location = $this->thumbnailDir . '/' . $this->thumbnailParams['thumbnailFileName'];
+            if ($this->filesystemThumb->exists($location)) {
+                if ($asStream === false) {
+                    $img = $this->filesystemThumb->read($location);
+                } else {
+                    $img = $this->filesystemThumb->readStream($location);
+                }
             }
             return isset($img) && $img ? $img : null;
         } catch (Exception $e) {
@@ -341,9 +370,10 @@ class AssetService extends AbstractService
      * https://css-tricks.com/almanac/properties/o/object-fit/
      *
      * @throws Exception
-     * @return string
+     * @param boolean $asStream
+     * @return string|resource
      */
-    public function contain()
+    public function contain($asStream = false)
     {
         try {
             $img = $this->load();
@@ -351,9 +381,13 @@ class AssetService extends AbstractService
                 $constraint->aspectRatio();
             });
             $encodedImg = (string) $img->encode($this->thumbnailParams['format'], ($this->thumbnailParams['quality'] ? $this->thumbnailParams['quality'] : null));
-            $this->filesystemThumb->write($this->thumbnailDir . '/' . $this->thumbnailParams['thumbnailFileName'], $encodedImg);
+            $location = $this->thumbnailDir . '/' . $this->thumbnailParams['thumbnailFileName'];
+            $this->filesystemThumb->write($location, $encodedImg);
 
-            return $encodedImg;
+            if ($asStream === false) {
+                return $encodedImg;
+            }
+            return $this->filesystemThumb->readStream($location);
         } catch (Exception $e) {
             throw $e;
         }
@@ -365,18 +399,23 @@ class AssetService extends AbstractService
      * https://css-tricks.com/almanac/properties/o/object-fit/
      *
      * @throws Exception
+     * @param boolean $asStream
      * @return string
      */
-    public function crop()
+    public function crop($asStream = false)
     {
         try {
             $img = $this->load();
             $img->fit($this->thumbnailParams['width'], $this->thumbnailParams['height'], function ($constraint) {
             });
             $encodedImg = (string) $img->encode($this->thumbnailParams['format'], ($this->thumbnailParams['quality'] ? $this->thumbnailParams['quality'] : null));
-            $this->filesystemThumb->write($this->thumbnailDir . '/' . $this->thumbnailParams['thumbnailFileName'], $encodedImg);
+            $location = $this->thumbnailDir . '/' . $this->thumbnailParams['thumbnailFileName'];
+            $this->filesystemThumb->write($location, $encodedImg);
 
-            return $encodedImg;
+            if ($asStream === false) {
+                return $encodedImg;
+            }
+            return $this->filesystemThumb->readStream($location);
         } catch (Exception $e) {
             throw $e;
         }

--- a/src/core/Directus/Services/FilesServices.php
+++ b/src/core/Directus/Services/FilesServices.php
@@ -6,6 +6,7 @@ use Directus\Application\Container;
 use Directus\Database\Schema\SchemaManager;
 use Directus\Exception\BadRequestException;
 use Directus\Exception\BatchUploadNotAllowedException;
+use Zend\Db\Sql\Select;
 use function Directus\is_a_url;
 use function Directus\validate_file;
 use function Directus\get_directus_setting;
@@ -13,7 +14,6 @@ use Directus\Util\ArrayUtils;
 use Directus\Util\DateTimeUtils;
 use Directus\Validator\Exception\InvalidRequestException;
 use function Directus\get_random_string;
-use Directus\Application\Application;
 
 class FilesServices extends AbstractService
 {
@@ -58,7 +58,7 @@ class FilesServices extends AbstractService
         }
 
         $recordData = $this->getSaveData($data, false);
-        
+
         $newFile = $tableGateway->createRecord($recordData, $this->getCRUDParams($params));
 
         return $tableGateway->wrapData(
@@ -86,7 +86,7 @@ class FilesServices extends AbstractService
         }
 
         $type = ArrayUtils::get($dataInfo, 'type', ArrayUtils::get($data, 'type'));
-      
+
         if (strpos($type, 'embed/') === 0) {
             $recordData = $files->saveEmbedData(array_merge($dataInfo, ArrayUtils::pick($data, ['filename_disk'])));
         } else {
@@ -105,7 +105,7 @@ class FilesServices extends AbstractService
         if (!$isUpdate) {
             $recordData['private_hash'] = get_random_string();
         }
-       
+
         return ArrayUtils::omit(array_merge($data, $recordData), ['data', 'html']);
     }
 
@@ -164,7 +164,7 @@ class FilesServices extends AbstractService
 
             try {
                 $this->container->get('filesystem')->getAdapter()->rename($oldFilePath, $newFilePath);
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 throw new InvalidRequestException($e);
             }
         }

--- a/src/endpoints/Assets.php
+++ b/src/endpoints/Assets.php
@@ -6,6 +6,7 @@ use Directus\Application\Route;
 use Directus\Application\Http\Request;
 use Directus\Application\Http\Response;
 use Directus\Services\AssetService;
+use Slim\Http\Stream;
 
 class Assets extends Route
 {
@@ -16,7 +17,8 @@ class Assets extends Route
 
         $asset = $service->getAsset(
             $fileId,
-            $request->getQueryParams()
+            $request->getQueryParams(),
+            true
         );
 
         if (isset($asset['file']) && $asset['mimeType']) {
@@ -24,10 +26,7 @@ class Assets extends Route
             $response->setHeader('Content-Disposition', 'filename="' . $asset['filename_download'] . '"');
             $response->setHeader('Last-Modified', $asset['last_modified']);
 
-            $body = $response->getBody();
-            $body->write($asset['file']);
-
-            return $response;
+            return $response->withBody(new Stream($asset['file']));
         } else {
             return $response->withStatus(404);
         }

--- a/src/endpoints/Files.php
+++ b/src/endpoints/Files.php
@@ -10,7 +10,6 @@ use Directus\Database\Schema\SchemaManager;
 use Directus\Exception\BatchUploadNotAllowedException;
 use Directus\Exception\Exception;
 use Directus\Filesystem\Exception\FailedUploadException;
-use function Directus\regex_numeric_ids;
 use Directus\Services\FilesServices;
 use Directus\Services\RevisionsService;
 use Directus\Util\ArrayUtils;
@@ -74,6 +73,13 @@ class Files extends Route
             $payload,
             $request->getQueryParams()
         );
+
+        // You can move place this define statement in other files if you're investigating
+        // memory usage and trying to nail down where it's coming from (you'll be able to
+        // see the memory usage at the point of the define() in the X-Memory-Usage response
+        // header).
+        //define('X_MEM_USAGE', memory_get_peak_usage(true));
+        //$response = $response->withHeader('X-Memory-Usage', X_MEM_USAGE);
 
         return $this->responseWithData($request, $response, $responseData);
     }


### PR DESCRIPTION
Fixes #1542. Adds an optional boolean parameter $asStream (default false) to several methods on AssetService and makes use of that parameter in the Assets route. I verified locally with memory_get_peak_usage while serving the original of a large image that the file was no longer being loaded into memory in its entirety.

(This is my first pull request ever.)