### PR TITLE
Fix #1789 Enable _all and _has filters in GraphQL endpoint

### DIFF
--- a/src/core/Directus/GraphQL/FieldsConfig.php
+++ b/src/core/Directus/GraphQL/FieldsConfig.php
@@ -186,12 +186,8 @@ class FieldsConfig
                     break;
 
                 default:
-                    /* As the _has and _all not working properly
-                    *  https://github.com/directus/api/issues/576
-                    *  We will fix once the issue in the REST endpoint will fix.
-                    */
-                    // $filters[$v['field'] . '_all'] = Types::nonNull(Types::string());
-                    // $filters[$v['field'] . '_has'] = Types::nonNull(Types::string());
+                    $filters[$v['field'] . '_all'] = Types::nonNull(Types::string());
+                    $filters[$v['field'] . '_has'] = Types::nonNull(Types::string());
             }
         }
         $filters['or'] = Types::listOf(Types::filters($this->collection));


### PR DESCRIPTION
* GraphQL does not allow filtering by `Slug` fields. It does allow filtering by Text fields. Both are underlying string fields though
* Found this part commented. The [corresponding issue](https://github.com/directus/api/issues/576) mentioned in the comment has been fixed

Fixes #1789