### PR TITLE
Add custom password reset url

### DIFF
--- a/src/core/Directus/Services/AuthService.php
+++ b/src/core/Directus/Services/AuthService.php
@@ -385,8 +385,9 @@ class AuthService extends AbstractService
      * Sends a email with the reset password token
      *
      * @param $email
+     * @param $customResetUrl
      */
-    public function sendResetPasswordToken($email)
+    public function sendResetPasswordToken($email, $customResetUrl)
     {
         $this->validate(['email' => $email], ['email' => 'required|email']);
 
@@ -402,7 +403,12 @@ class AuthService extends AbstractService
         ]);
         // Sending the project key in the query param makes sure the app will use the correct project
         // to send the new password to
-        $resetUrl = get_url() . 'admin/#/reset-password?token=' . $resetToken . '&project=' . get_api_project_from_request();
+
+        if ($customResetUrl) {
+            $resetUrl = $customResetUrl . '?token=' .$resetToken;
+        } else {
+            $resetUrl = get_url() . 'admin/#/reset-password?token=' . $resetToken . '&project=' . get_api_project_from_request();
+        }
 
         \Directus\send_forgot_password_email($user->toArray(), $resetUrl);
     }

--- a/src/core/Directus/Services/AuthService.php
+++ b/src/core/Directus/Services/AuthService.php
@@ -405,7 +405,7 @@ class AuthService extends AbstractService
         // to send the new password to
 
         if ($customResetUrl) {
-            $resetUrl = $customResetUrl . '?token=' .$resetToken;
+            $resetUrl = $customResetUrl . '?token=' . $resetToken;
         } else {
             $resetUrl = get_url() . 'admin/#/reset-password?token=' . $resetToken . '&project=' . get_api_project_from_request();
         }

--- a/src/core/Directus/Services/AuthService.php
+++ b/src/core/Directus/Services/AuthService.php
@@ -385,9 +385,9 @@ class AuthService extends AbstractService
      * Sends a email with the reset password token
      *
      * @param $email
-     * @param $customResetUrl
+     * @param $reset_url
      */
-    public function sendResetPasswordToken($email, $customResetUrl)
+    public function sendResetPasswordToken($email, $reset_url)
     {
         $this->validate(['email' => $email], ['email' => 'required|email']);
 
@@ -404,8 +404,8 @@ class AuthService extends AbstractService
         // Sending the project key in the query param makes sure the app will use the correct project
         // to send the new password to
 
-        if ($customResetUrl) {
-            $resetUrl = $customResetUrl . '?token=' . $resetToken;
+        if ($reset_url) {
+            $resetUrl = $reset_url . '?token=' . $resetToken;
         } else {
             $resetUrl = get_url() . 'admin/#/reset-password?token=' . $resetToken . '&project=' . get_api_project_from_request();
         }

--- a/src/endpoints/Auth.php
+++ b/src/endpoints/Auth.php
@@ -267,7 +267,8 @@ class Auth extends Route
 
         try {
             $authService->sendResetPasswordToken(
-                $request->getParsedBodyParam('email')
+                $request->getParsedBodyParam('email'),
+                $request->getParsedBodyParam('customResetUrl')
             );
         } catch (\Exception $e) {
             $this->container->get('logger')->error($e->getMessage());

--- a/src/endpoints/Auth.php
+++ b/src/endpoints/Auth.php
@@ -268,7 +268,7 @@ class Auth extends Route
         try {
             $authService->sendResetPasswordToken(
                 $request->getParsedBodyParam('email'),
-                $request->getParsedBodyParam('customResetUrl')
+                $request->getParsedBodyParam('reset_url')
             );
         } catch (\Exception $e) {
             $this->container->get('logger')->error($e->getMessage());


### PR DESCRIPTION
I wan't to handle the password reset flow on my own frontend.
This PR adds the option to send a reset url to the `/:project/auth/password/request` endpoint.

If this gets approved I can update the docs and js-sdk accordingly.