### PR TITLE
Fix 1795: Fix GraphQL regressions in 8.6.0

### DIFF
--- a/src/core/Directus/GraphQL/FieldsConfig.php
+++ b/src/core/Directus/GraphQL/FieldsConfig.php
@@ -192,8 +192,8 @@ class FieldsConfig
                     break;
 
                 default:
-                    $filters[$v['field'] . '_all'] = Types::nonNull(Types::string());
-                    $filters[$v['field'] . '_has'] = Types::nonNull(Types::string());
+                    $filters[$v['field'] . '_all'] = Types::string();
+                    $filters[$v['field'] . '_has'] = Types::string();
             }
         }
         $filters['or'] = Types::listOf(Types::filters($this->collection));

--- a/src/core/Directus/GraphQL/FieldsConfig.php
+++ b/src/core/Directus/GraphQL/FieldsConfig.php
@@ -77,20 +77,6 @@ class FieldsConfig
                     $fields[$v['field']] = Types::userCollection($collection);
                     break;
                 case 'o2m':
-                    $relation = $this->getRelation('o2m', $v['collection'], $v['field']);
-                    if ($v['interface'] == 'one-to-many') {
-                        $fields[$v['field']] = Types::listOf(Types::userCollection($relation['collection_many']));
-                    } else {
-                        $fields[$v['field']] = [];
-                        $fields[$v['field']]['type'] = Types::listOf(Types::userCollection($relation['collection_one']));
-                        $fields[$v['field']]['resolve'] = function ($value, $args, $context, $info) use ($relation) {
-                            $data = [];
-                            foreach ($value[$info->fieldName] as $v) {
-                                $data[] = $v[$relation['field_many']];
-                            }
-                            return $data;
-                        };
-                    }
                 case 'translation': // translation is just an o2m collection
                     $collection = $this->getOtherCollectionOneToMany(
                         $v['collection'], $v['field']);


### PR DESCRIPTION
* Fixes #1795
* Fix `_has` and `_all` filters being marked as `nonNull`, they are optional

Tested both in our deployment, and with these two fixes, it's working fine.