### PR TITLE
Configure token TTL value

### DIFF
--- a/migrations/install/20180220023123_create_fields_table.php
+++ b/migrations/install/20180220023123_create_fields_table.php
@@ -235,6 +235,13 @@ class CreateFieldsTable extends AbstractMigration
                 'interface' => 'many-to-one',
                 'locked' => 1
             ],
+            [
+                'collection' => 'directus_fields',
+                'field' => 'auth_token_ttl',
+                'type' => \Directus\Database\Schema\DataTypes::TYPE_INTEGER,
+                'interface' => 'numeric',
+                'locked' => 1
+            ]
         ];
 
         foreach ($data as $value) {

--- a/migrations/install/20180220023243_create_settings_table.php
+++ b/migrations/install/20180220023243_create_settings_table.php
@@ -229,6 +229,19 @@ class CreateSettingsTable extends AbstractMigration
             ],
             [
                 'collection' => 'directus_settings',
+                'field' => 'auth_token_ttl',
+                'type' => 'integer',
+                'note' => 'Minutes the API authorization token will last',
+                'interface' => 'numeric',
+                'options' => json_encode([
+                    'iconRight' => 'timer'
+                ]),
+                'sort' => 25,
+                'locked' => 1,
+                'width' => 'half'
+            ],
+            [
+                'collection' => 'directus_settings',
                 'field' => 'files_divider',
                 'type' => \Directus\Database\Schema\DataTypes::TYPE_ALIAS,
                 'interface' => 'divider',
@@ -437,6 +450,10 @@ class CreateSettingsTable extends AbstractMigration
             [
                 'key' => 'login_attempts_allowed',
                 'value' => '25'
+            ],
+            [
+                'key' => 'auth_token_ttl',
+                'value' => '20'
             ],
             [
                 'key' => 'trusted_proxies',

--- a/migrations/upgrades/20200303111750_add_auth_ttl_field.php
+++ b/migrations/upgrades/20200303111750_add_auth_ttl_field.php
@@ -1,0 +1,69 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddAuthTtlField extends AbstractMigration
+{
+    public function up()
+    {
+        $settings = [
+            'auth_token_ttl' => [
+                // for directus_fields
+                'type' => 'integer',
+                'interface' => 'numeric',
+                'options' => '{\"iconRight\":\"timer\"}',
+                // 'locked' => 1,
+                // 'validation' => null,
+                'required' => 1,
+                // 'readonly' => 0,
+                // 'hidden_detail' => 0,
+                // 'hidden_browse' => 0,
+                'sort' => 25,
+                'width' => 'half',
+                // 'height' => null,
+                // 'group' => null,
+                'note' => 'How long the API authorization token will last',
+                // 'translation' => null,
+
+                // for directus_settings
+                'value' => 20,
+            ]
+        ];
+        foreach ($settings as $field => $options) {
+            $this->addSetting($field, $options['value']);
+            $this->addField($field, $options['type'], $options['interface'], $options['options'], $options['required'], $options['sort'], $options['width'], $options['note']);
+        }
+    }
+
+    protected function addField($field, $type, $interface, $options, $required, $sort, $width, $note)
+    {
+        $collection = 'directus_settings';
+        $checkSql = sprintf('SELECT 1 FROM `directus_fields` WHERE `collection` = "%s" AND `field` = "%s";', $collection, $field);
+        $result = $this->query($checkSql)->fetch();
+        if (!$result)
+        {
+            $insertSqlFormat = 'INSERT INTO `directus_fields` (`collection`, `field`, `type`, `interface`, `options`, `required`, `sort`, `width`, `note`) VALUES ("%s", "%s", "%s", "%s", "%s","%s", "%s", "%s", "%s")';
+            $insertSql = sprintf($insertSqlFormat, $collection, $field, $type, $interface, $options, $required, $sort, $width, $note);
+            $res = $this->execute($insertSql);
+        }
+    }
+
+    protected function addSetting($key, $value)
+    {
+        $checkSql = sprintf('SELECT 1 FROM `directus_settings` WHERE `key` = "%s"', $key);
+        $result = $this->query($checkSql)->fetch();
+        if (!$result)
+        {
+            $insertSqlFormat = 'INSERT INTO `directus_settings` (`key`, `value`) VALUES ("%s", "%s")';
+            $insertSql = sprintf($insertSqlFormat, $key, $value);
+            $res = $this->execute($insertSql);
+        }
+    }
+
+    public function down()
+    {
+        $this->execute("DELETE FROM directus_settings where `key`='auth_token_ttl'");
+        $this->execute("DELETE FROM directus_fields where collection='directus_settings' and field='auth_token_ttl'");
+    }
+
+}

--- a/src/core/Directus/Application/CoreServicesProvider.php
+++ b/src/core/Directus/Application/CoreServicesProvider.php
@@ -742,6 +742,7 @@ class CoreServicesProvider
                 [
                     'secret_key' => $container->get('config')->get('auth.secret_key'),
                     'public_key' => $container->get('config')->get('auth.public_key'),
+                    'ttl' => $container->get('config')->get('auth.ttl'),
                 ]
             );
         };

--- a/src/core/Directus/Authentication/Provider.php
+++ b/src/core/Directus/Authentication/Provider.php
@@ -80,7 +80,7 @@ class Provider
             throw new Exception('auth: secret key is required and it must be a string');
         }
 
-        $ttl = ArrayUtils::get($options, 'ttl', 20);
+        $ttl = get_directus_setting('auth_token_ttl', ArrayUtils::get($options, 'ttl', 20));
         if (!is_numeric($ttl)) {
             throw new Exception('ttl must be a number');
         }
@@ -435,7 +435,8 @@ class Provider
         $payload = [
             'id' => (int) $user->getId(),
             // 'group' => $user->getGroupId(),
-            'exp' => $this->getNewExpirationTime()
+            'exp' => $this->getNewExpirationTime(),
+            'ttl' => $this->ttl,
         ];
 
 
@@ -455,7 +456,8 @@ class Provider
             'type' => 'request_token',
             'id' => (int) $user->getId(),
             // 'group' => (int) $user->getGroupId(),
-            'exp' => time() + (20 * DateTimeUtils::MINUTE_IN_SECONDS),
+            'exp' => time() + ($this->ttl * DateTimeUtils::MINUTE_IN_SECONDS),
+            'ttl' => $this->ttl,
             'url' => \Directus\get_url(),
             'project' => \Directus\get_api_project_from_request()
         ];
@@ -476,7 +478,8 @@ class Provider
             'id' => (int) $user->getId(),
             'email' => $user->getEmail(),
             // TODO: Separate time expiration for reset password token
-            'exp' => $this->getNewExpirationTime()
+            'exp' => $this->getNewExpirationTime(),
+            'ttl' => $this->ttl
         ];
 
         return $this->generateToken(JWTUtils::TYPE_RESET_PASSWORD, $payload);

--- a/src/core/Directus/Config/Schema/Schema.php
+++ b/src/core/Directus/Config/Schema/Schema.php
@@ -122,6 +122,7 @@ class Schema
             new Group('auth', [
                 new Value('secret_key', Types::STRING, '<type-a-secret-authentication-key-string>'),
                 new Value('public_key', Types::STRING, '<type-a-public-authentication-key-string>'),
+                new Value('ttl', Types::INTEGER, 20),
                 new Group('social_providers', [
                     new Group('okta?', [
                         new Value('client_id', Types::STRING, ''),

--- a/src/core/Directus/Util/Installation/InstallerUtils.php
+++ b/src/core/Directus/Util/Installation/InstallerUtils.php
@@ -952,6 +952,7 @@ class InstallerUtils
         $corsEnabled = ArrayUtils::get($data, 'cors_enabled', true);
         $authSecret = ArrayUtils::get($data, 'auth_secret', StringUtils::randomString(32, false));
         $authPublic = ArrayUtils::get($data, 'auth_public', generate_uuid4());
+        $ttl = ArrayUtils::get($data, 'ttl', 20);
 
         return ArrayUtils::defaults([
             'project' => '_',
@@ -1004,6 +1005,7 @@ class InstallerUtils
             'auth' => [
                 'secret' => $authSecret,
                 'public' => $authPublic,
+                'ttl' => $ttl
             ]
         ], $data);
     }

--- a/src/core/Directus/Util/Installation/stubs/config.stub
+++ b/src/core/Directus/Util/Installation/stubs/config.stub
@@ -76,6 +76,7 @@ return [
     'auth' => [
         'secret_key' => '{{auth.secret}}',
         'public_key' => '{{auth.public}}',
+        'ttl' => {{auth.ttl}},
         'social_providers' => [
             {{optional(auth.social_providers.okta)}},
             {{optional(auth.social_providers.github)}},


### PR DESCRIPTION
Hello Directus team,

I'd like the temporary token expiration to be configurable (currently defaults to 20 minutes). Currently it is not configurable.

This patch keeps the old behaviour, but allows the project config PHP file a new entry to configure the TTL token expiration, example:
```
    'auth' => [
        'secret_key' => 'XXX',
        'public_key' => '12345678-1234-1234-1234-123456789012',
        'ttl' => 60,
       .....
```
After a new Directus project installation, this behaviour can be controlled from the Directus backoffice panel:

![2020-03-03_20-03-1583262228](https://user-images.githubusercontent.com/6098822/76009645-d6bcc680-5f11-11ea-9390-f8d4fcf5d7a9.png)

Thanks for reviewing this!

cc: @herrfinke
