### PR TITLE
Fix auth.ttl param retrieval

### DIFF
--- a/src/core/Directus/Authentication/Provider.php
+++ b/src/core/Directus/Authentication/Provider.php
@@ -80,7 +80,7 @@ class Provider
             throw new Exception('auth: secret key is required and it must be a string');
         }
 
-        $ttl = get_directus_setting('auth_token_ttl', ArrayUtils::get($options, 'ttl', 20));
+        $ttl = get_directus_setting('auth_token_ttl', ArrayUtils::get($options, 'auth.ttl', 20));
         if (!is_numeric($ttl)) {
             throw new Exception('ttl must be a number');
         }


### PR DESCRIPTION
This should fix [this regression](https://github.com/directus/api/pull/1798#issuecomment-610238505). The new authorization time-to-live parameter was not correclty parsed when using the directus command line.

I've tested this change using the command line to change the password of a user

`$ bin/directus user:password --e user@host.com -p mypwd -k project_name`

and by creating a brand new project using the admin web app running on localhost (therefore project creation and migrations seem to work like before)