### PR TITLE
Invalide length text returned by WS #1860

### DIFF
--- a/src/core/Directus/Database/Schema/SchemaManager.php
+++ b/src/core/Directus/Database/Schema/SchemaManager.php
@@ -80,9 +80,11 @@ class SchemaManager
      * @var array
      */
     protected $noLengthDataTypes = [        
+        'TEXT',
         'TINYTEXT',
         'MEDIUMTEXT',
         'LONGTEXT',
+        'BLOB',
         'TINYBLOB',
         'MEDIUMBLOB',
         'LONGBLOB'


### PR DESCRIPTION
TEXT and BLOB don't have real length
https://dev.mysql.com/doc/refman/5.7/en/storage-requirements.html
https://dev.mysql.com/doc/refman/8.0/en/storage-requirements.html

Fixes #1860