### PR TITLE
Dispatch hook actions when users attempt to sign into the Directus App.

### DIFF
--- a/src/core/Directus/Authentication/Provider.php
+++ b/src/core/Directus/Authentication/Provider.php
@@ -176,7 +176,7 @@ class Provider
         // Verify that the user has an id (exists), it returns empty user object otherwise
         if (!password_verify($password, $user->get('password'))) {
 			
-			$hookEmitter->run('auth.fail', [$user]);
+			$hookEmitter->run('auth.fail', [$user, 'app']);
             $this->recordActivityAndCheckLoginAttempt($user);
             throw new InvalidUserCredentialsException();
         }
@@ -197,7 +197,7 @@ class Provider
 
         $this->user = $user;
         
-        $hookEmitter->run('auth.success', [$user]);
+        $hookEmitter->run('auth.success', [$user, 'app']);
 
         return $user;
     }


### PR DESCRIPTION
HOOK: auth.success and auth.fail.
TODO: The directus_settings.login_attempts_allowed is not activated when authenticating through the App.