### PR TITLE
icon path to be relative

### DIFF
--- a/src/core/Directus/Services/AuthService.php
+++ b/src/core/Directus/Services/AuthService.php
@@ -153,7 +153,7 @@ class AuthService extends AbstractService
         $type = $service->getConfig()->get('custom') === true ? 'custom' : 'core';
         $iconPath = sprintf('/extensions/%s/auth/%s/icon.svg', $type, $name);
         if (file_exists($basePath . '/public' . $iconPath)) {
-            $iconUrl = \Directus\get_url($iconPath);
+            $iconUrl = $iconPath;
         }
 
         return [


### PR DESCRIPTION
As per #1887 
removed geturl function call so the iconPath would be the relative path when it's sourced in the img tag.

 `<img data-v-a1b23a0e="" src="/extensions/core/auth/okta/icon.svg" alt="okta">`

Fixes #1887