### PR TITLE
Add SameSite=None Secure to cookies

### DIFF
--- a/src/core/Directus/Application/Http/Middleware/ResponseCacheMiddleware.php
+++ b/src/core/Directus/Application/Http/Middleware/ResponseCacheMiddleware.php
@@ -99,7 +99,10 @@ class ResponseCacheMiddleware extends AbstractMiddleware
                             ]
                         );
 
-                        $response =  $response->withAddedHeader('Set-Cookie', $cookie->toHeaders());
+                        $cookieAsString = $cookie->toHeaders()[0];
+                        $cookieAsString .= '; SameSite=None; Secure';
+
+                        $response =  $response->withAddedHeader('Set-Cookie', $cookieAsString);
                         break;
                     default:
                         $userSession = $userSessionService->find(['token' => $authorizationTokenObject['token']]);
@@ -122,7 +125,10 @@ class ResponseCacheMiddleware extends AbstractMiddleware
                 ]
             );
 
-            $response =  $response->withAddedHeader('Set-Cookie', $cookie->toHeaders());
+            $cookieAsString = $cookie->toHeaders()[0];
+            $cookieAsString .= '; SameSite=None; Secure';
+
+            $response =  $response->withAddedHeader('Set-Cookie', $cookieAsString);
         }
 
         $config = $container->get('config');

--- a/src/endpoints/Auth.php
+++ b/src/endpoints/Auth.php
@@ -175,7 +175,10 @@ class Auth extends Route
             ]
         );
 
-        return  $response->withAddedHeader('Set-Cookie', $cookie->toHeaders());
+        $cookieAsString = $cookie->toHeaders()[0];
+        $cookieAsString .= '; SameSite=None; Secure';
+
+        return  $response->withAddedHeader('Set-Cookie', $cookieAsString);
     }
 
     /**


### PR DESCRIPTION
This adds `SameSite=None; Secure` to the cookie provided in cookie mode for auth, which ensures the API won't break when the browsers update their cookie policy to require those.

Fixes https://github.com/directus/api/issues/1819
Fixes https://github.com/directus/api/issues/1385