### PR TITLE
adding dynamic env var support for external oauth service

### DIFF
--- a/src/core/Directus/Application/CoreServicesProvider.php
+++ b/src/core/Directus/Application/CoreServicesProvider.php
@@ -783,6 +783,10 @@ class CoreServicesProvider
                     $class = array_get($providerInfo, 'provider');
                     $custom = array_get($providerInfo, 'custom');
 
+                    if ($custom && !class_exists($class)) {
+                        require_once(\Directus\base_path().'public/extensions/custom/auth/'.$providerName.'/Provider.php');
+                    }
+
                     if (!class_exists($class)) {
                         throw new RuntimeException(sprintf('Class %s not found', $class));
                     }

--- a/src/core/Directus/Config/Context.php
+++ b/src/core/Directus/Config/Context.php
@@ -127,4 +127,9 @@ class Context
     {
         return getenv('DIRECTUS_USE_ENV') === '1';
     }
+
+    public static function has_custom_context()
+    {
+        return getenv('DIRECTUS_USE_CUSTOM_CONTEXT') === '1';
+    }
 }

--- a/src/core/Directus/Config/Schema/Base.php
+++ b/src/core/Directus/Config/Schema/Base.php
@@ -121,7 +121,7 @@ abstract class Base implements Node
      */
     protected function normalize($context) {
         foreach ($context as $context_key => $context_value) {
-            $context[strtolower(str_replace("-", "", str_replace("_", "", $context_key)))] = $context_value;
+            $context[strtolower(preg_replace('/[^a-zA-Z0-9]/', '', $context_key))] = $context_value;
         }
 
         return $context;

--- a/src/core/Directus/Config/Schema/Base.php
+++ b/src/core/Directus/Config/Schema/Base.php
@@ -128,11 +128,18 @@ abstract class Base implements Node
     }
 
     /**
-     * @param self $child
+     * @param self $newChild
+     * @return Base
      */
-    public function addChild($child)
+    public function addChild($newChild)
     {
-        $child->parent($this);
-        $this->_children[] = $child;
+        $newChild->parent($this);
+        $children = array_filter($this->_children, function ($child) use ($newChild) {
+            /** @var Base $child */
+            return $child->key() !== $newChild->key();
+        });
+        $children[] = $newChild;
+        $this->children($children);
+        return $this;
     }
 }

--- a/src/core/Directus/Config/Schema/Base.php
+++ b/src/core/Directus/Config/Schema/Base.php
@@ -126,4 +126,13 @@ abstract class Base implements Node
 
         return $context;
     }
+
+    /**
+     * @param self $child
+     */
+    public function addChild($child)
+    {
+        $child->parent($this);
+        $this->_children[] = $child;
+    }
 }

--- a/src/core/Directus/Config/Schema/Schema.php
+++ b/src/core/Directus/Config/Schema/Schema.php
@@ -172,32 +172,29 @@ class Schema
     }
 
     /**
-     * @param Group|Node|Node[] $group
+     * @param Base|Node|Node[] $group
      * @param array $keys
      * @param Value $newChild
-     * @return Group
+     * @return Base
      */
-    private static function saveCustomNode($group, $keys, $newChild) {
+    private static function saveCustomNode($group, $keys, $newChild)
+    {
         $key = strtolower(self::normalizeNodeName(array_shift($keys)));
-        /** @var Group[] $children */
         if (count($keys) == 0) {
-            $group->addChild($newChild);
-            return $group;
+            return $group->addChild($newChild);
         }
         foreach($group->children() as $child) {
             if ($child->key() === $key) {
                 if (count($keys) >= 1) {
-                    return self::saveCustomNode($child, $keys, $newChild);
+                    return $group->addChild(self::saveCustomNode($child, $keys, $newChild));
                 }
             }
         }
-        // there are still keys left and the current key is not found means we need a new child
         if (count($keys) > 0) {
             $newGroup = new Group($key, []);
             $newGroup = self::saveCustomNode($newGroup, $keys, $newChild);
-            $group->addChild($newGroup);
+            return $group->addChild($newGroup);
         }
         return $group;
     }
-
 }


### PR DESCRIPTION
The problem:

I was deploying directus/directus from the base image onto a kubernetes instance via a helm chart and making the configurations via env vars. 
I added our extensions for our SSO (keycloak) via a folder and added that into the pod / container.
It turned out however, that no matter what I did, the keycloak was not loaded and I would have to create an api.php containing all the settings I need as a config file including our keycloak config. That would kill my flexibility with the env vars, so I did not want to live with that.
Aside from that, after I added a custom api.php I ran into the problem, that the custom auth file was not loaded, because the CoreServiceProvider did not read and include files from the custom folder.

The solution:

The first thing I did was add an if to the CoreServiceProvider to read a class from the custom auth folder if there would be a custom auth class and the class was not yet known.

secondly, I updated the Schema creation process.

To get a bit deeper on that. I wanted to change the settings for the schema according to the used env vars. So I added an env var to activate a custom context DIRECTUS_USE_CUSTOM_CONTEXT

if that is activated, the workflow works as following. It searches through the env vars and looks for DIRECTUS_CUSTOM_* variables. Those variables should contain informations on the fields to be added to the schema. Afterwards, the Schema will be enhanced and the enhanced schema will be returned to the algorithm reading the env vars into the config container to be used within directus

