### PR TITLE
Make cookie SameSite / Secure configurable

### DIFF
--- a/config/_example.php
+++ b/config/_example.php
@@ -40,6 +40,11 @@ return [
         'credentials' => false,     // Access-Control-Allow-Credentials
     ],
 
+    'cookie' => [                   // Controls for the auth cookie mode
+        'same_site' => 'Strict',    // Set the SameSite flag
+        'secure' => false           // Add the Secure flag
+    ],
+
     'rate_limit' => [
         'enabled' => false,         // Enable or disable all rate limiting
         'limit' => 100,             // Number of requests allowed...

--- a/src/core/Directus/Application/Http/Middleware/ResponseCacheMiddleware.php
+++ b/src/core/Directus/Application/Http/Middleware/ResponseCacheMiddleware.php
@@ -100,7 +100,12 @@ class ResponseCacheMiddleware extends AbstractMiddleware
                         );
 
                         $cookieAsString = $cookie->toHeaders()[0];
-                        $cookieAsString .= '; SameSite=None; Secure';
+
+                        $cookieAsString .= '; SameSite=' . $config->get('cookie.same_site');
+
+                        if ($config->get('cookie.secure')) {
+                            $cookieAsString .= '; Secure';
+                        }
 
                         $response =  $response->withAddedHeader('Set-Cookie', $cookieAsString);
                         break;
@@ -126,7 +131,12 @@ class ResponseCacheMiddleware extends AbstractMiddleware
             );
 
             $cookieAsString = $cookie->toHeaders()[0];
-            $cookieAsString .= '; SameSite=None; Secure';
+
+            $cookieAsString .= '; SameSite=' . $config->get('cookie.same_site');
+
+            if ($config->get('cookie.secure')) {
+                $cookieAsString .= '; Secure';
+            }
 
             $response =  $response->withAddedHeader('Set-Cookie', $cookieAsString);
         }

--- a/src/core/Directus/Config/Schema/Schema.php
+++ b/src/core/Directus/Config/Schema/Schema.php
@@ -93,6 +93,10 @@ class Schema
                     new Value('encryption?', Types::STRING, ''),
                 ]),
             ]),
+            new Group('cookie', [
+                new Value('same_site', Types::STRING, 'Lax'),
+                new Value('secure', Types::BOOLEAN, false),
+            ]),
             new Group('cors', [
                 new Value('enabled', Types::BOOLEAN, true),
                 new Value('origin', Types::ARRAY, ['*']),

--- a/src/core/Directus/Util/Installation/InstallerUtils.php
+++ b/src/core/Directus/Util/Installation/InstallerUtils.php
@@ -977,6 +977,10 @@ class InstallerUtils
             'mail' => [
                 'transport' => 'sendmail',
             ],
+            'cookie' => [
+                'same_site' => 'Lax',
+                'secure' => false,
+            ],
             'cors' => [
                 'enabled' => $corsEnabled,
                 'origin' => ['*'],

--- a/src/core/Directus/Util/Installation/stubs/config.stub
+++ b/src/core/Directus/Util/Installation/stubs/config.stub
@@ -14,6 +14,11 @@ return [
         'socket' => '{{db_socket}}',
     ],
 
+    'cookie' => [
+        'same_site' => {{cookie.same_site}},
+        'secure' => {{cookie.secure}}
+    ],
+
     'cors' => [
         'enabled' => {{cors.enabled}},
         'origin' => {{cors.origin}},

--- a/src/endpoints/Auth.php
+++ b/src/endpoints/Auth.php
@@ -145,6 +145,7 @@ class Auth extends Route
      */
     public function storeCookieSession($request, $response, $data)
     {
+        $config = $this->container->get('config');
         $authorizationTokenObject = get_request_authorization_token($request);
         $expiry= $this->getSessionExpiryTime();
         $userSessionService = new UserSessionService($this->container);
@@ -176,7 +177,12 @@ class Auth extends Route
         );
 
         $cookieAsString = $cookie->toHeaders()[0];
-        $cookieAsString .= '; SameSite=None; Secure';
+
+        $cookieAsString .= '; SameSite=' . $config->get('cookie.same_site');
+
+        if ($config->get('cookie.secure')) {
+            $cookieAsString .= '; Secure';
+        }
 
         return  $response->withAddedHeader('Set-Cookie', $cookieAsString);
     }


### PR DESCRIPTION
This allows the default installation to rely on `SameSite=Lax` without `Secure`, which should work for most people. Only when you start relying on cross-domain cookies in the `mode: cookie` login strategy would you have to configure this to `Secure` in order to prevent the browsers from blocking the cookie