### PR TITLE
Improve string to int/float cast

### DIFF
--- a/src/core/Directus/Database/TableGateway/BaseTableGateway.php
+++ b/src/core/Directus/Database/TableGateway/BaseTableGateway.php
@@ -645,7 +645,24 @@ class BaseTableGateway extends TableGateway
     public function castFloatIfNumeric(&$value, $key)
     {
         if ($key != 'table_name') {
-            $value = is_numeric($value) && preg_match('/^-?(?:\d+|\d*\.\d+)$/', $value) ? (float) $value : $value;
+
+            // anything that "looks like" a number
+            if(is_numeric($value)) {
+
+                // match any string with a comma
+                // e.g. "3.14159265358979323846264338327950288419"
+                // warning: number will be truncated to 16 digits (IEEE 754)
+                if(preg_match('/^-?(\d*\.\d+)$/', $value) === TRUE) {
+                    $value = (float) $value;
+                }
+
+                // match any string with an integer number
+                // of any integer number, e.g.
+                // "+/-14159265358979323846264338327950288419"
+                // +/-14159265358979323846264338327950288419
+                else
+                    $value = (int) $value;
+            }
         }
     }
 


### PR DESCRIPTION
Hi,

I think there is a problem when the id of a record is a BIGINT. It looks like the string sent from the app is not always properly casted to integer/float resulting sometimes in a broken SQL query.

Example, we have this primary key `8004372939997067670` (a BIGINT in MySQL) and the generated query looks like (shortened for readability):

```
SELECT
    "test_table"."id" AS "id", ......
FROM
    "test_table"
WHERE
    CAST(`test_table`.`id` as CHAR) IN ('8.0043729399971E+18')
ORDER BY ...
LIMIT '1'
OFFSET '0'
```

To give more context on my research, from what I could understand, the cause of the issue is a brittle parsing introduced two years ago and not really fixed in a [subsequent patch](https://github.com/directus/api/pull/899) last year that introduced a regexp.

As I don't know much of the internals of Directus, I'd be happy to have a feedback on this, I can have easily missed something obvious.

Thanks you!


cc: @herrfinke