### PR TITLE
Fix record creation when table PK is not the AUTO_INCREMENT field

### DIFF
--- a/src/core/Directus/Database/TableGateway/BaseTableGateway.php
+++ b/src/core/Directus/Database/TableGateway/BaseTableGateway.php
@@ -398,9 +398,26 @@ class BaseTableGateway extends TableGateway
         if ($columnObject->hasAutoIncrement()) {
             $recordData[$primaryKey] = $TableGateway->getLastInsertValue();
         }
+        else if ($columnObject->hasPrimaryKey())
+        {
+            // identify the autoincrement field+value to retrieve the new record
+            $fieldAutoIncrement = null;
+            foreach($this->getTableSchema()->getFields() as $f) {
+                if ($f->hasAutoIncrement()) {
+                    $fieldAutoIncrement = $f->getName();
+                    $lastInsertValue = $TableGateway->getLastInsertValue();
+                    break;
+                }
+            }
+
+            // retrieve the full record
+            if (isset($fieldAutoIncrement)) {
+                $record = $this->findOneBy($fieldAutoIncrement, $lastInsertValue);
+                $recordData[$primaryKey] = $record[$primaryKey];
+            }
+        }
 
         $columns = SchemaService::getAllNonAliasCollectionFieldNames($this->table);
-
         return $TableGateway->fetchAll(function (Select $select) use ($recordData, $columns, $primaryKey) {
             $select
                 ->columns($columns)
@@ -797,6 +814,22 @@ class BaseTableGateway extends TableGateway
         }
 
         $resultData = $insertTableGateway->find($generatedValue);
+
+        // try to retrieve the record using another field
+        if (empty($resultData)) {
+            $columnObject = $this->getTableSchema()->getField($this->primaryKeyFieldName);
+            if ($columnObject->hasPrimaryKey()) {
+                $fieldAutoIncrement = null;
+                foreach($this->getTableSchema()->getFields() as $f) {
+                    $fieldAutoIncrement = $f->getName();
+                    $lastInsertValue = $this->getLastInsertValue();
+                    break;
+                }
+
+                if (isset($fieldAutoIncrement))
+                    $resultData = $this->findOneBy($fieldAutoIncrement, $lastInsertValue);
+            }
+        }
 
         if ($useFilter) {
             $this->runHook('item.create', [$insertTable, $resultData]);


### PR DESCRIPTION
Hello,

This is a draft to discuss a problem we have with hooks.

We have a table with such (very simplified) structure:

```
CREATE TABLE test_table (
  id int(11) NOT NULL AUTO_INCREMENT,
  pk_field bigint(11) NOT NULL PRIMARY KEY,
  name varchar(128)
);
```

This is our workflow:

- `test_table` is managed. The Directus App allows the user to only add a new record using the `name` field, the other two are hidden.
- After the form is submitted we have a `item.create.test_table:before` hook that populates the `pk_field`, the hook obviously only receives the `name` field.
- After the record is created we have another `item.create.test_table:after` hook that does other stuff and to do that needs the full record created before.

Now, for reasons that are not completely clear to me, the record fails to be created when the auto increment field does not match with the primary key field (Directus seems to always trust that they match).

I've dug into Directus internals but I'm not confident I got it right, but here's a tentative patch to start a discussion on this behaviour (which breaks our workflow).

I didn't investigate deeply:
- If this patch breaks other workflows (I don't have enough context)
- what's the performance cost of this patch (don't know enough of Zend framework)

By the way, I think this problem is also related to [this issue](https://github.com/directus/api/issues/1909).

I'd be really happy to receive feedback, comment and improvements on this one.

Thanks!

cc: @herrfinke