### PR TITLE
Fix Google OAuth invalid_grant error

### DIFF
--- a/public/extensions/core/auth/google/Provider.php
+++ b/public/extensions/core/auth/google/Provider.php
@@ -35,6 +35,7 @@ class Provider extends TwoSocialProvider
             'redirectUri'       => $this->getRedirectUrl(),
             'hostedDomain'      => $this->config->get('hosted_domain'),
             'useOidcMode'       => (bool) $this->config->get('use_oidc_mode'),
+            'accessType'        => 'offline',
         ]);
 
         return $this->provider;


### PR DESCRIPTION
We're continuously seeing `invalid_grant` errors when trying to login with Google OAuth. This seems to be a very popular issue indeed: https://blog.timekit.io/google-oauth-invalid-grant-nightmare-and-how-to-fix-it-9f4efaf1da35

Testing some potential fixes. Will open PR when one of those work.