### PR TITLE
Corrects level of 'env' key/value for default/unknown project app configuration to prevent leaking of technical information

### DIFF
--- a/src/helpers/app.php
+++ b/src/helpers/app.php
@@ -221,9 +221,7 @@ if (!function_exists('create_ping_server')) {
     function create_ping_server($basePath, array $config = [], array $values = [])
     {
         $app = create_app($basePath, array_merge([
-            'app' => [
-                'env' => 'production',
-            ],
+            'env' => 'production'
         ], $config), $values);
 
         $app->group('/server', function () {
@@ -253,9 +251,7 @@ if (!function_exists('create_default_app')) {
         }
 
         $app = create_app($basePath, array_merge([
-            'app' => [
-                'env' => 'production',
-            ],
+            'env' => 'production'
         ], $config), $values);
 
         $app->add(new CorsMiddleware($app->getContainer(), true));


### PR DESCRIPTION
I noticed that the ping app and "unknown" project app configurations always fell back to a `development` configuration. So when hitting an unknown endpoint (e.g. example.com/test) which would be routed via the unknown-project app, the response would contain details that should probably be kept private, such as PHP file paths and such. This is since these apps still use the regular error handlers, which return more information when in `development` configuration.

It looks like it _was_ the intention for these two apps to default to a `production` configuration, but because the `env` had been placed in an object called `app` instead of the root, the error handling code couldn't find it where it expected it, and therefore defaulted to "development".

As a side note, it looks like there are a few places in the codebase that default to `development` e.g. `->get('env', 'development')`. Perhaps these should default to `production` to be on the safer side?

Before fix:
<img width="1339" alt="Before" src="https://user-images.githubusercontent.com/4376956/86644254-4680b200-bfd5-11ea-9e43-1af26c0450f5.png">

After fix:
<img width="476" alt="After" src="https://user-images.githubusercontent.com/4376956/86644360-5b5d4580-bfd5-11ea-897e-e78d9944545c.png">
