### PR TITLE
Use withAddedHeader function to add headers to the response, instead of replacing it.

### DIFF
--- a/src/core/Directus/Application/Http/Middleware/CorsMiddleware.php
+++ b/src/core/Directus/Application/Http/Middleware/CorsMiddleware.php
@@ -62,7 +62,7 @@ class CorsMiddleware extends AbstractMiddleware
                // TODO: Remove withHeaders calls here
                 return $response
                     ->withHeader('Access-Control-Allow-Credentials', 'true')
-                    ->withHeader('Access-Control-Allow-Headers', ['X-Directus-Project', 'Content-Type', 'Authorization']);
+                    ->withAddedHeader('Access-Control-Allow-Headers', ['X-Directus-Project', 'Content-Type', 'Authorization']);
             } else {
                 $this->processActualHeaders($request, $response);
             }


### PR DESCRIPTION
User can add headers to response using the configuration file
has describe here: config/_example.php.
Inside the src/core/Directus/Application/Http/Middleware/CorsMiddleware.php
class these options will be applied, calling the function processPreflightHeaders.
Later we append some custom headers, which shouldn't override users headers.

Signed-off-by: Eithel <tux.eithel@gmail.com>