### PR TITLE
Fix: honor meta params in `ItemsService->findAll` method

### DIFF
--- a/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
+++ b/src/core/Directus/Database/TableGateway/RelationalTableGateway.php
@@ -906,16 +906,16 @@ class RelationalTableGateway extends BaseTableGateway
      *
      * @return array
      */
-    public function wrapData($data, $single = false, $meta = false)
+    public function wrapData($data, $single = false, $meta = false, $params = [])
     {
-        $result = [];
+        $result = [];      
 
         if ($meta) {
             if (!is_array($meta)) {
                 $meta = StringUtils::csv($meta);
             }
 
-            $result['meta'] = $this->createMetadata($data, $single, $meta);
+            $result['meta'] = $this->createMetadata($data, $single, $meta, $params);
         }
 
         $result['data'] = $data;
@@ -927,13 +927,13 @@ class RelationalTableGateway extends BaseTableGateway
         return $result;
     }
 
-    public function createMetadata($entriesData, $single, $list = [])
+    public function createMetadata($entriesData, $single, $list = [], $params = [])
     {
         $singleEntry = $single || !ArrayUtils::isNumericKeys($entriesData);
         $metadata = $this->createGlobalMetadata($singleEntry, $list);
 
         if (!$singleEntry) {
-            $metadata = array_merge($metadata, $this->createEntriesMetadata($entriesData, $list));
+            $metadata = array_merge($metadata, $this->createEntriesMetadata($entriesData, $list, $params));
         }
 
         return $metadata;
@@ -975,7 +975,7 @@ class RelationalTableGateway extends BaseTableGateway
      *
      * @return array
      */
-    public function createEntriesMetadata(array $entries, array $list = [])
+    public function createEntriesMetadata(array $entries, array $list = [], array $params = [])
     {
         $allKeys = ['result_count', 'total_count', 'filter_count', 'status', 'page'];
         $tableSchema = $this->getTableSchema($this->table);
@@ -1009,7 +1009,7 @@ class RelationalTableGateway extends BaseTableGateway
         }
 
         if (in_array('filter_count', $list) || in_array('page', $list)) {
-            $metadata = $this->createMetadataPagination($metadata, $this::$container->get('request')->getQueryParams(), $countedData);
+            $metadata = $this->createMetadataPagination($metadata, $params, $countedData);
         }
 
         return $metadata;
@@ -1286,7 +1286,7 @@ class RelationalTableGateway extends BaseTableGateway
 
         $items = $this->fetchItems($params);
 
-        return $this->wrapData($items, $single, $meta);
+        return $this->wrapData($items, $single, $meta, $params);
     }
 
     /**
@@ -2296,7 +2296,8 @@ class RelationalTableGateway extends BaseTableGateway
                 $tableGateway->wrapData(
                     $relatedEntries[$rowId],
                     true,
-                    ArrayUtils::get($params, 'meta', 0)
+                    ArrayUtils::get($params, 'meta', 0),
+                    $params
                 );
             }
 

--- a/src/core/Directus/Services/TablesService.php
+++ b/src/core/Directus/Services/TablesService.php
@@ -232,7 +232,8 @@ class TablesService extends AbstractService
             $result = $tableGateway->wrapData(
                 $this->mergeSchemaField($columnObject),
                 true,
-                ArrayUtils::pick($params, 'meta')
+                ArrayUtils::pick($params, 'meta'),
+                $params
             );
         }
 


### PR DESCRIPTION
### Issue
When using the `ItemsService` query method `findAll` and setting the params by code, the `meta` query parameter is not honored.
So, the following custom endpoint code:
```php
return [
    '' => [
        'method' => 'GET',
        'handler' => function (Request $request, Response $response) {
            $itemsService = new ItemsService($this);

            $fixedParams = [
                'filter' => [
                    'name' => [
                        'rlike' => 'a%'
                    ]
                ],
                'meta' => 'filter_count,page'
            ];
            $result = $itemsService->findAll('people', $fixedParams);
        
            return $response->withJson($result);
        }
    ],
];
```
Will return no `meta` information. Other meta details, such as `result_count`, `total_count`, `collection` will still work.


### Why this happens
Inside `src/core/Directus/Database/TableGateway/RelationalTableGateway.php`, on line [1012](https://github.com/directus/api/blob/ebbb339140fd3223311a428fa720abc27cbac7e1/src/core/Directus/Database/TableGateway/RelationalTableGateway.php#L1012), instead of passing the `$params` from the context to `createMetadataPagination()`, the code is reaching out to `$this::$container->get('request')->getQueryParams()` and getting the params from the request.

The problem is that the method [`createEntriesMetadata()`](https://github.com/directus/api/blob/ebbb339140fd3223311a428fa720abc27cbac7e1/src/core/Directus/Database/TableGateway/RelationalTableGateway.php#L978) doesn't have the `$params` at all, since it's only dealing with a sanitized version of the metadata array. But [`createMetadataPagination()`](https://github.com/directus/api/blob/ebbb339140fd3223311a428fa720abc27cbac7e1/src/core/Directus/Database/TableGateway/RelationalTableGateway.php#L1026) needs more information to create the metadata pagination.


### Fix
In order to fix that, I've added the `$params` array as a new parameter of the [`wrapData()`](https://github.com/directus/api/blob/ebbb339140fd3223311a428fa720abc27cbac7e1/src/core/Directus/Database/TableGateway/RelationalTableGateway.php#L909) method. I've added as the last parameter with a default value to avoid breaking anything else, since `wrapData` is a public method.
That parameter had to be cascaded down to `createMetadata()` and `createEntriesMetadata()` methods as well, both also having default values.

Looking for references to the `wrapData()` method around the project, the only place that also would make sense to add the `$params` is `src/core/Directus/Services/TablesService.php`'s `findField()` method.

Please, let me know if there's anything else that I should do to make this fix work.