### PR TITLE
Fix validation of the fields: If no fields are given, default should be to validate all fields

### DIFF
--- a/src/core/Directus/Services/AbstractService.php
+++ b/src/core/Directus/Services/AbstractService.php
@@ -11,6 +11,7 @@ use Directus\Database\RowGateway\BaseRowGateway;
 use Directus\Database\Schema\DataTypes;
 use Directus\Database\Schema\SchemaManager;
 use Directus\Database\TableGateway\RelationalTableGateway;
+use Directus\Database\SchemaService;
 use Directus\Database\TableGatewayFactory;
 use Directus\Exception\ForbiddenException;
 use Directus\Exception\UnprocessableEntityException;
@@ -379,7 +380,7 @@ abstract class AbstractService
      */
     protected function validatePayload($collectionName, $fields, array $payload, array $params, $skipRelatedCollectionField = '')
     {
-        $columnsToValidate = [];
+        $columnsToValidate = SchemaService::getFieldsName($collectionName);
 
         // TODO: Validate empty request
         // If the user PATCH, POST or PUT with empty body, must throw an exception to avoid continue the execution


### PR DESCRIPTION
Hi, I had the problem, that the fields, which are marked as "required" were neither validated by creation of item nor by the update, if for example the text input was cleared again (Version: 8.8.1) 

After some debugging, I've found out, that the fields which were empty on ui (e.g. on create screen) were not send to the backend. The backend on the other hand didn't consider than these fields to be validated, because there was no list of constraints to be checked for these fields (`$columnsToValidate` in the `validatePayload` method)

I could fix the errors, as I replaced the default value of this variable to be all fields of the collection. From my point of view during the validation all constraints (Requirement is implemented as one of the constraints as I understand) should be considered, if no fields are provided (which is the case for all calls from ItemService for example)

**Please note:** since I'm was not able to find open issues regarding the validation as whole,  I'm something wondering, that such essential functionality didn't work for me. So I would like to ask the core team to check this before merge in the master branch. 

Thank you and best regards