### PR TITLE
Performance fix for Response tagging

### DIFF
--- a/src/core/Directus/Cache/Response.php
+++ b/src/core/Directus/Cache/Response.php
@@ -8,6 +8,13 @@ class Response extends Cache
 
     public function tag($tags)
     {
+    	//array_merge is a performance killer when running in a loop (which this method is often called from)
+		//if the given value is a scalar anyway, we dont need to call array_merge at all
+    	if (is_scalar($tags)) {
+			$this->tags[] = $tags;
+			return $this;
+		}
+        
         $this->tags = array_merge($this->tags, (array)$tags);
 
         return $this;


### PR DESCRIPTION
In certain situations the Response->tag() method is called a couple of thousand times when saving a record. This results in very long request times.
This patch improves this. (>1min vs 2,6s)

Problem faced with directus 8.8.1 with having a collection that has a many-to-many relation to another collection. Now when having a couple of relations set (~10) and then re-sort these in the frontend and saving the record results in a PATCH http call which duration rises exponentially with the number of related records.

Found the problem with blackfire.io:
![image](https://user-images.githubusercontent.com/1571485/92083787-cacd9680-edc6-11ea-808f-7aaa57b3913f.png)
