### PR TITLE
Fix #1926 (Adds UTC version of created_on field to the payload)

### DIFF
--- a/src/core/Directus/Application/CoreServicesProvider.php
+++ b/src/core/Directus/Application/CoreServicesProvider.php
@@ -299,9 +299,12 @@ class CoreServicesProvider
 
                 /** @var Acl $acl */
                 $acl = $container->get('acl');
+
                 if ($dateCreated = $collection->getDateCreatedField()) {
-                    $dateCreatedValue =  DateTimeUtils::createFromDateTime(new \DateTime($payload[$dateCreated->getName()]));
-                    $payload[$dateCreated->getName()] = $dateCreatedValue->toUTCString();
+                    if ($payload[$dateCreated->getName()] !== null) {
+                        $dateCreatedValue =  DateTimeUtils::createFromDateTime(new \DateTime($payload[$dateCreated->getName()]));
+                        $payload[$dateCreated->getName()] = $dateCreatedValue->toUTCString();
+                    }
                 }
                 
                 if ($dateModified = $collection->getDateModifiedField()) {

--- a/src/core/Directus/Application/CoreServicesProvider.php
+++ b/src/core/Directus/Application/CoreServicesProvider.php
@@ -300,7 +300,8 @@ class CoreServicesProvider
                 /** @var Acl $acl */
                 $acl = $container->get('acl');
                 if ($dateCreated = $collection->getDateCreatedField()) {
-                    $payload[$dateCreated->getName()] = DateTimeUtils::nowInUTC()->toString();
+                    $dateCreatedValue =  DateTimeUtils::createFromDateTime(new \DateTime($payload[$dateCreated->getName()]));
+                    $payload[$dateCreated->getName()] = $dateCreatedValue->toUTCString();
                 }
                 
                 if ($dateModified = $collection->getDateModifiedField()) {

--- a/src/core/Directus/Application/CoreServicesProvider.php
+++ b/src/core/Directus/Application/CoreServicesProvider.php
@@ -299,6 +299,10 @@ class CoreServicesProvider
 
                 /** @var Acl $acl */
                 $acl = $container->get('acl');
+                if ($dateCreated = $collection->getDateCreatedField()) {
+                    $payload[$dateCreated->getName()] = DateTimeUtils::nowInUTC()->toString();
+                }
+                
                 if ($dateModified = $collection->getDateModifiedField()) {
                     $payload[$dateModified->getName()] = DateTimeUtils::nowInUTC()->toString();
                 }


### PR DESCRIPTION
This code change fixing suppose to fix the issued described in the following tickets:

Fixes https://github.com/directus/api/issues/1926
Fixes https://github.com/directus/app/issues/2834

The created_on field is part of the update request for translations data, but its not converted to UTC when update is processing. It's causing TableGateway to fail when updateWith method is called