### PR TITLE
ingnore invalid characters from exif-metadata

### DIFF
--- a/src/core/Directus/Services/FilesServices.php
+++ b/src/core/Directus/Services/FilesServices.php
@@ -95,12 +95,16 @@ class FilesServices extends AbstractService
         }
 
         // NOTE: Use the user input title, tags, description and location when exists.
-        $recordData = ArrayUtils::defaults($recordData, ArrayUtils::pick($data, [
-            'title',
-            'tags',
-            'description',
-            'location',
-        ]));
+        $exifTags = array('title','tags','description','location');
+        $recordData = ArrayUtils::defaults($recordData, ArrayUtils::pick($data, $exifTags));
+
+        foreach ($exifTags as $key) {
+            if(array_key_exists($key, $recordData)) {
+                // NOTE: remove all non-utf8 characters from exif metadata, because they'll break
+                // the mysql insert on zend
+                $recordData[$key] = iconv("UTF-8","UTF-8//IGNORE",$recordData[$key]);
+            }
+        }
 
         if (!$isUpdate) {
             $recordData['private_hash'] = get_random_string();


### PR DESCRIPTION
solves #1999 

simply loop over all metadata fields which are used for metadata retrieval. Remove all non utf8 characters. 

Tested with different images, works fine and uploading of files with invalid exif-data is not resulting in sql error anymore.